### PR TITLE
BRMS-249: filter out middle names on record

### DIFF
--- a/app/uk/gov/hmrc/brm/config/BrmConfig.scala
+++ b/app/uk/gov/hmrc/brm/config/BrmConfig.scala
@@ -44,7 +44,7 @@ trait BrmConfig extends ServicesConfig {
 
   def nameMaxLength : Int = getConfInt("birth-registration-matching.validation.maxNameLength", 250)
 
-  val ignoreMiddleNamesRegex : String = getConfString("birth-registration-matching.matching.ignoreMiddleNames.regex", throw BirthConfigurationException("ignoreMiddleNames"))
+  val ignoreMiddleNamesRegex : String = getConfString("birth-registration-matching.matching.ignoreMiddleNamesRegex", throw BirthConfigurationException("ignoreMiddleNames"))
   def ignoreMiddleNames : Boolean = getConfBool("birth-registration-matching.matching.ignoreMiddleNames", throw BirthConfigurationException("ignoreMiddleNames"))
 
 }

--- a/app/uk/gov/hmrc/brm/config/BrmConfig.scala
+++ b/app/uk/gov/hmrc/brm/config/BrmConfig.scala
@@ -18,8 +18,15 @@ package uk.gov.hmrc.brm.config
 
 import uk.gov.hmrc.play.config.ServicesConfig
 
-trait BrmConfig extends ServicesConfig
-{
+trait BrmConfig extends ServicesConfig {
+
+  case class BirthConfigurationException(switch: String) extends RuntimeException {
+    override def toString: String = {
+      val m = s"birth-registration-matching.matching.$switch configuration not found"
+      m
+    }
+  }
+
   def validateDobForGro: Boolean = getConfBool("birth-registration-matching.validateDobForGro", defBool = false)
   def minimumDateValueForGroValidation: String = getConfString("birth-registration-matching.validDateForGro", "1900-01-01")
 
@@ -34,7 +41,11 @@ trait BrmConfig extends ServicesConfig
   def matchOnMultiple : Boolean = getConfBool("birth-registration-matching.matching.matchOnMultiple", defBool = false)
 
   def disableSearchByDetails : Boolean = getConfBool("birth-registration-matching.matching.disableSearchByDetails", defBool = false)
+
   def nameMaxLength : Int = getConfInt("birth-registration-matching.validation.maxNameLength", 250)
+
+  val ignoreMiddleNamesRegex : String = getConfString("birth-registration-matching.matching.ignoreMiddleNames.regex", throw BirthConfigurationException("ignoreMiddleNames"))
+  def ignoreMiddleNames : Boolean = getConfBool("birth-registration-matching.matching.ignoreMiddleNames", throw BirthConfigurationException("ignoreMiddleNames"))
 
 }
 

--- a/app/uk/gov/hmrc/brm/services/MatchingAlgorithm.scala
+++ b/app/uk/gov/hmrc/brm/services/MatchingAlgorithm.scala
@@ -87,16 +87,23 @@ trait MatchingAlgorithm {
 
 object FullMatching extends MatchingAlgorithm {
 
+  private def firstName(payload: Payload, record: Record): String = {
+
+    def concat(x: String, y: String): String = s"$x $y"
+
+    if(BrmConfig.ignoreMiddleNames)
+    {
+      record.child.firstName
+    }
+    else
+    {
+      record.child.firstName.names.slice(0, payload.firstName.names.length).reduceLeft(concat)
+    }
+  }
+
   override def matchFunction: PartialFunction[(Payload, Record), ResultMatch] = {
     case (payload, record) =>
-
-      //TODO CHRIS FOLLOW HERE
-//      val firstName = payload.firstName.names
-//      val firstNamesOnrRecord = record.child.firstName.names
-      // we need to drop names from the record that don't exist in the firstNameList input?
-      // make string again? then exact match?
-
-      val firstNames = nameMatch(Some(payload.firstName), Some(record.child.firstName))
+      val firstNames = nameMatch(Some(payload.firstName), Some(firstName(payload, record)))
       val lastNames = nameMatch(Some(payload.lastName), Some(record.child.lastName))
       val dates = dobMatch(Some(payload.dateOfBirth), record.child.dateOfBirth)
       val resultMatch = firstNames and lastNames and dates

--- a/app/uk/gov/hmrc/brm/services/MatchingAlgorithm.scala
+++ b/app/uk/gov/hmrc/brm/services/MatchingAlgorithm.scala
@@ -93,11 +93,11 @@ object FullMatching extends MatchingAlgorithm {
 
     if(BrmConfig.ignoreMiddleNames)
     {
-      record.child.firstName
+      record.child.firstName.names.slice(0, payload.firstName.names.length).reduceLeft(concat)
     }
     else
     {
-      record.child.firstName.names.slice(0, payload.firstName.names.length).reduceLeft(concat)
+      record.child.firstName
     }
   }
 

--- a/app/uk/gov/hmrc/brm/services/MatchingAlgorithm.scala
+++ b/app/uk/gov/hmrc/brm/services/MatchingAlgorithm.scala
@@ -21,55 +21,61 @@ import uk.gov.hmrc.brm.config.BrmConfig
 import uk.gov.hmrc.brm.models.brm.Payload
 import uk.gov.hmrc.brm.models.matching.ResultMatch
 import uk.gov.hmrc.brm.models.response.Record
+import uk.gov.hmrc.brm.services.parser.NameParser._
 
 import scala.annotation.tailrec
 
 trait MatchingAlgorithm {
 
+  private[MatchingAlgorithm] lazy val ignoreMiddleNames : Boolean = BrmConfig.ignoreMiddleNames
   private[MatchingAlgorithm] val noMatch = ResultMatch(Bad(), Bad(), Bad(), Bad())
 
-  protected[MatchingAlgorithm] val matchFunction: PartialFunction[(Payload, Record), ResultMatch]
+  protected[MatchingAlgorithm] def matchFunction: PartialFunction[(Payload, Record), ResultMatch]
 
-  def performMatch(payload: Payload, records: List[Record], matchOnMultiple: Boolean = false): ResultMatch = {
+  def performMatch(payload: Payload, records: List[Record], matchOnMultiple: Boolean): ResultMatch = {
     @tailrec
     def matchHelper(records: List[Record], result: ResultMatch, f: ((Payload, Record)) => ResultMatch): ResultMatch = {
       records match {
-        case Nil => noMatch
+        case Nil =>
+          // no records returned therefore no match was found
+          noMatch
         case head :: Nil =>
+          // 1 record returned therefore we will attempt to match
           f(payload, head)
         case head :: tail =>
+          // multiple records returned, iterate these until a match is found
           val r = f(payload, head)
           matchHelper(tail, r, f)
       }
     }
 
+    // do we enable matching on multiple records returned
     if (matchOnMultiple) {
       matchHelper(records, noMatch, matchFunction)
-    }
-    else {
+    } else {
       records.length match {
-        case 1 => matchHelper(records, noMatch, matchFunction)
-        case _ => noMatch
+        case 1 =>
+          // one record returned, attempt to match
+          matchHelper(records, noMatch, matchFunction)
+        case _ =>
+          // more than 1 record was returned therefore it's no match
+          noMatch
       }
     }
   }
 
-  protected[MatchingAlgorithm] def firstNamesMatch(brmsFirstname: Option[String], groFirstName: Option[String]): Match =
-    matching[String](brmsFirstname, groFirstName, _ equalsIgnoreCase _)
+  protected[MatchingAlgorithm] def nameMatch(input: Option[String], record: Option[String]): Match =
+    matching[String](input, record, _ equalsIgnoreCase _)
 
-  protected[MatchingAlgorithm] def lastNameMatch(brmsLastName: Option[String], groLastName: Option[String]): Match =
-    matching[String](brmsLastName, groLastName, _ equalsIgnoreCase _)
-
-  protected[MatchingAlgorithm] def dobMatch(brmsDob: Option[LocalDate], groDob: Option[LocalDate]): Match =
-    matching[LocalDate](brmsDob, groDob, _ isEqual _)
+  protected[MatchingAlgorithm] def dobMatch(input: Option[LocalDate], record: Option[LocalDate]): Match =
+    matching[LocalDate](input, record, _ isEqual _)
 
   protected[MatchingAlgorithm] def matching[T](input: Option[T], other: Option[T], matchFunction: (T, T) => Boolean): Match = {
     (input, other) match {
       case (Some(x), Some(y)) =>
         if (matchFunction(x, y)) {
           Good()
-        }
-        else {
+        } else {
           Bad()
         }
       case _ => Bad()
@@ -81,10 +87,17 @@ trait MatchingAlgorithm {
 
 object FullMatching extends MatchingAlgorithm {
 
-  override val matchFunction: PartialFunction[(Payload, Record), ResultMatch] = {
+  override def matchFunction: PartialFunction[(Payload, Record), ResultMatch] = {
     case (payload, record) =>
-      val firstNames = firstNamesMatch(Some(payload.firstName), Some(record.child.firstName))
-      val lastNames = lastNameMatch(Some(payload.lastName), Some(record.child.lastName))
+
+      //TODO CHRIS FOLLOW HERE
+//      val firstName = payload.firstName.names
+//      val firstNamesOnrRecord = record.child.firstName.names
+      // we need to drop names from the record that don't exist in the firstNameList input?
+      // make string again? then exact match?
+
+      val firstNames = nameMatch(Some(payload.firstName), Some(record.child.firstName))
+      val lastNames = nameMatch(Some(payload.lastName), Some(record.child.lastName))
       val dates = dobMatch(Some(payload.dateOfBirth), record.child.dateOfBirth)
       val resultMatch = firstNames and lastNames and dates
 
@@ -94,17 +107,17 @@ object FullMatching extends MatchingAlgorithm {
 
 object PartialMatching extends MatchingAlgorithm {
 
-  override val matchFunction: PartialFunction[(Payload, Record), ResultMatch] = {
+  override def matchFunction: PartialFunction[(Payload, Record), ResultMatch] = {
     case (payload, record) =>
 
       val firstNames = if (BrmConfig.matchFirstName) {
-        firstNamesMatch(Some(payload.firstName), Some(record.child.firstName))
+        nameMatch(Some(payload.firstName), Some(record.child.firstName))
       } else {
         Good()
       }
 
       val lastNames = if (BrmConfig.matchLastName) {
-        lastNameMatch(Some(payload.lastName), Some(record.child.lastName))
+        nameMatch(Some(payload.lastName), Some(record.child.lastName))
       } else {
         Good()
       }

--- a/app/uk/gov/hmrc/brm/services/MatchingAlgorithm.scala
+++ b/app/uk/gov/hmrc/brm/services/MatchingAlgorithm.scala
@@ -27,7 +27,7 @@ import scala.annotation.tailrec
 
 trait MatchingAlgorithm {
 
-  private[MatchingAlgorithm] lazy val ignoreMiddleNames : Boolean = BrmConfig.ignoreMiddleNames
+  private[MatchingAlgorithm] def ignoreMiddleNames : Boolean = BrmConfig.ignoreMiddleNames
   private[MatchingAlgorithm] val noMatch = ResultMatch(Bad(), Bad(), Bad(), Bad())
 
   protected[MatchingAlgorithm] def matchFunction: PartialFunction[(Payload, Record), ResultMatch]
@@ -98,7 +98,7 @@ trait MatchingAlgorithm {
         val names = left filter right
         names.listToString
       case false =>
-        record.child.firstName
+        record.child.firstName.names.listToString
     }
   }
 

--- a/app/uk/gov/hmrc/brm/services/MatchingAlgorithm.scala
+++ b/app/uk/gov/hmrc/brm/services/MatchingAlgorithm.scala
@@ -110,11 +110,9 @@ object FullMatching extends MatchingAlgorithm {
   // TODO also call names() on lastName to strip out the spaces from the record
   override def matchFunction: PartialFunction[(Payload, Record), ResultMatch] = {
     case (payload, record) =>
-
       val firstNames = matchFirstNames(payload, record)
-      val lastNames = nameMatch(Some(payload.lastName), Some(record.child.lastName))
+      val lastNames = nameMatch(Some(payload.lastName.names.listToString), Some(record.child.lastName.names.listToString))
       val dates = dobMatch(Some(payload.dateOfBirth), record.child.dateOfBirth)
-
       val resultMatch = firstNames and lastNames and dates
 
       ResultMatch(firstNames, lastNames, dates, resultMatch)

--- a/app/uk/gov/hmrc/brm/services/MatchingService.scala
+++ b/app/uk/gov/hmrc/brm/services/MatchingService.scala
@@ -41,6 +41,7 @@ trait MatchingService {
     val algorithm = matchingType match {
       case MatchingType.FULL => FullMatching
       case MatchingType.PARTIAL => PartialMatching
+      case _ => FullMatching
     }
 
     val result = algorithm.performMatch(input, records, matchOnMultiple)
@@ -51,14 +52,12 @@ trait MatchingService {
     info(CLASS_NAME, "performMatch", s" hasMultipleRecords -> $multipleRecords")
 
     CommonUtil.getOperationType(input) match {
-      case DetailsRequest() => {
+      case DetailsRequest() =>
         BRMAudit.auditRequest(new EnglandAndWalesAuditEvent(result.audit, "birth-registration-matching/match/details"),
           records, multipleRecords, "GRO/details", hc)
-      }
-      case ReferenceRequest() => {
+      case ReferenceRequest() =>
         BRMAudit.auditRequest(new EnglandAndWalesAuditEvent(result.audit),
           records, multipleRecords, "GRO/match", hc)
-      }
     }
 
     result

--- a/app/uk/gov/hmrc/brm/services/parser/NameParser.scala
+++ b/app/uk/gov/hmrc/brm/services/parser/NameParser.scala
@@ -30,10 +30,18 @@ object NameParser {
 
     def names: List[String] = {
       BrmLogger.debug("NameParser", "parser regex", regex)
-      val nameArray: Array[String] = s.trim.split(regex)
+      val nameArray: Array[String] = s.toLowerCase.trim.split(regex)
       BrmLogger.debug("NameParser", "parse", s"${nameArray.toList}")
 
       nameArray.toList
+    }
+
+  }
+
+  implicit class FilterList[T](left : List[T]) {
+
+    def filter[T](right : List[T]) : List[T] = {
+      Nil
     }
 
   }

--- a/app/uk/gov/hmrc/brm/services/parser/NameParser.scala
+++ b/app/uk/gov/hmrc/brm/services/parser/NameParser.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.brm.services.parser
+
+import uk.gov.hmrc.brm.config.BrmConfig
+import uk.gov.hmrc.brm.utils.BrmLogger
+
+/**
+  * Created by adamconder on 02/02/2017.
+  */
+object NameParser {
+
+  implicit class NameParserImplicit(val s: String) {
+
+    lazy val regex = BrmConfig.ignoreMiddleNamesRegex
+
+    def names: List[String] = {
+      BrmLogger.debug("NameParser", "parser regex", regex)
+      val nameArray: Array[String] = s.split(regex)
+      BrmLogger.debug("NameParser", "parse", s"${nameArray.toList}")
+
+      nameArray.toList
+    }
+
+  }
+
+}

--- a/app/uk/gov/hmrc/brm/services/parser/NameParser.scala
+++ b/app/uk/gov/hmrc/brm/services/parser/NameParser.scala
@@ -30,7 +30,7 @@ object NameParser {
 
     def names: List[String] = {
       BrmLogger.debug("NameParser", "parser regex", regex)
-      val nameArray: Array[String] = s.split(regex)
+      val nameArray: Array[String] = s.trim.split(regex)
       BrmLogger.debug("NameParser", "parse", s"${nameArray.toList}")
 
       nameArray.toList

--- a/app/uk/gov/hmrc/brm/services/parser/NameParser.scala
+++ b/app/uk/gov/hmrc/brm/services/parser/NameParser.scala
@@ -29,9 +29,8 @@ object NameParser {
     lazy val regex = BrmConfig.ignoreMiddleNamesRegex
 
     def names: List[String] = {
-      BrmLogger.debug("NameParser", "parser regex", regex)
       val nameArray: Array[String] = s.toLowerCase.trim.split(regex)
-      BrmLogger.debug("NameParser", "parse", s"${nameArray.toList}")
+      BrmLogger.debug("NameParser", "parse", s"names: ${nameArray.toList}, regex: $regex")
 
       nameArray.toList
     }
@@ -40,9 +39,26 @@ object NameParser {
 
   implicit class FilterList[T](left : List[T]) {
 
-    def filter[T](right : List[T]) : List[T] = {
-      Nil
+    def filter(right : List[T]) : List[T] = {
+      BrmLogger.debug("NameParser", "filter", s"left: $left right: $right")
+
+      if (left.length > right.length || left.isEmpty || right.isEmpty) {
+        right
+      } else {
+        val difference = right.length - left.length
+        BrmLogger.debug("NameParser", "parser", s"dropping: $difference")
+        val dropped = right.dropRight(difference)
+        BrmLogger.debug("NameParser", "parser", s"dropped: $dropped")
+        dropped
+      }
     }
+
+  }
+
+  implicit class StringListToString(left: List[String]) {
+
+    def listToString : String =
+      left.foldLeft("")((x, acc) => s"$x $acc").trim
 
   }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -135,6 +135,7 @@ auditing {
 }
 
 microservice {
+
   metrics {
     graphite {
       host = graphite
@@ -145,10 +146,12 @@ microservice {
   }
 
   services {
+
     auth {
       host=localhost
       port=8500
     }
+
     birth-registration-matching {
       host = localhost
       port = 9006
@@ -157,12 +160,15 @@ microservice {
       validateDobForGro = false
       validDateForGro = "2009-07-01"
       minimumDateOfBirthYear = 1900
+
       matching {
         firstName = true
         lastName = true
         dateOfBirth = true
         matchOnMultiple = false
         disableSearchByDetails = false
+        ignoreMiddleNames = true
+        ignoreMiddleNames.regex = "\\s+"
       }
 
       validation {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -168,7 +168,7 @@ microservice {
         matchOnMultiple = false
         disableSearchByDetails = false
         ignoreMiddleNames = true
-        ignoreMiddleNames.regex = "\\s+"
+        ignoreMiddleNamesRegex = "\\s+"
       }
 
       validation {

--- a/test/uk/gov/hmrc/brm/BRMFakeApplication.scala
+++ b/test/uk/gov/hmrc/brm/BRMFakeApplication.scala
@@ -21,14 +21,24 @@ import org.scalatest.Suite
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.play.test.WithFakeApplication
 
+object BaseConfig {
+
+  val config: Map[String, _] = Map(
+    "auditing.enabled" -> false,
+    "auditing.traceRequests" -> false,
+    "metrics.enabled" -> false,
+    "microservice.metrics.graphite.enabled" -> false
+  )
+
+}
+
 trait BRMFakeApplication extends WithFakeApplication {
   this: Suite =>
 
   override def bindModules = Seq(new PlayModule)
 
-  val config: Map[String, _] = Map(
-    "microservice.services.birth-registration-matching.validateDobForGro" -> true
-  )
+  val config : Map[String, _] = BaseConfig.config
+    .++(Map("microservice.services.birth-registration-matching.validateDobForGro" -> true))
 
   override lazy val fakeApplication = GuiceApplicationBuilder(
     disabled = Seq(classOf[com.kenshoo.play.metrics.PlayModule])

--- a/test/uk/gov/hmrc/brm/services/MatchingServiceSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/MatchingServiceSpec.scala
@@ -310,7 +310,7 @@ class MatchingServiceSpec extends UnitSpec with MockitoSugar with BRMFakeApplica
             }
 
             s"($name) match when firstName argument has all middle names on input that on are the record, with additional spaces" in {
-              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
                 val payload = Payload(reference, " Adam    David   ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
                 val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
@@ -318,7 +318,7 @@ class MatchingServiceSpec extends UnitSpec with MockitoSugar with BRMFakeApplica
             }
 
             s"($name) match when firstName argument has all middle names on input that on are the record, with additional spaces on the record" in {
-              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
                 val payload = Payload(reference, "Adam David", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
                 val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
@@ -335,7 +335,7 @@ class MatchingServiceSpec extends UnitSpec with MockitoSugar with BRMFakeApplica
             }
 
             s"($name) not match when firstName argument has too many names not on the record, with additional spaces on record" in {
-              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
                 val payload = Payload(reference, "Adam David James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
                 val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
                 resultMatch.isMatch shouldBe false

--- a/test/uk/gov/hmrc/brm/services/MatchingServiceSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/MatchingServiceSpec.scala
@@ -19,17 +19,16 @@ package uk.gov.hmrc.brm.services
 import org.joda.time.LocalDate
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.mock.MockitoSugar
-import org.scalatestplus.play.OneAppPerSuite
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeApplication
 import play.api.test.Helpers._
-import uk.gov.hmrc.brm.{BRMFakeApplication, BaseConfig}
 import uk.gov.hmrc.brm.config.BrmConfig
 import uk.gov.hmrc.brm.models.brm.Payload
 import uk.gov.hmrc.brm.utils.TestHelper._
 import uk.gov.hmrc.brm.utils.{BirthRegisterCountry, MatchingType}
+import uk.gov.hmrc.brm.{BRMFakeApplication, BaseConfig}
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
-import play.api.test.FakeApplication
 
 
 
@@ -220,6 +219,8 @@ class MatchingServiceSpec extends UnitSpec with MockitoSugar with BRMFakeApplica
       - Lower case matching
       - Upper case on input matching
       - Upper case on record matching
+      * Match surname if it contains multiple names
+      * Match surname if it contains multiple names with more than one space
      */
 
     "matching a single record" should {
@@ -297,6 +298,14 @@ class MatchingServiceSpec extends UnitSpec with MockitoSugar with BRMFakeApplica
               }
             }
 
+            s"($name) match when lastName from record contains multiple spaces between names and includes space at beginning and end of string" in {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+                val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameMultipleSpaceBeginningTrailing), MatchingType.FULL)
+                resultMatch.isMatch shouldBe true
+              }
+            }
+
           }
 
           "not ignore middle names with feature toggle disabled" should {
@@ -342,6 +351,14 @@ class MatchingServiceSpec extends UnitSpec with MockitoSugar with BRMFakeApplica
               }
             }
 
+            s"($name) match when lastName from record contains multiple spaces between names and includes space at beginning and end of string" in {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
+                val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+                val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameMultipleSpaceBeginningTrailing), MatchingType.FULL)
+                resultMatch.isMatch shouldBe true
+              }
+            }
+
           }
 
           s"($name) match when firstName contains special characters" in {
@@ -372,6 +389,38 @@ class MatchingServiceSpec extends UnitSpec with MockitoSugar with BRMFakeApplica
             running(FakeApplication()) {
               val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
               val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameSpace), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
+          }
+
+          s"($name) match when lastName from record contains multiple spaces between names" in {
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jones  Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameSpace), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
+          }
+
+          s"($name) match when lastName from payload contains multiple spaces between names and includes space at beginning and end of string" in {
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "  Jones  Smith  ", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameSpace), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
+          }
+
+          s"($name) match when lastName from payload contains multiple spaces between names" in {
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameMultipleSpace), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
+          }
+
+          s"($name) match when lastName from record contains multiple spaces between names and includes space at beginning and end of string" in {
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameMultipleSpaceBeginningTrailing), MatchingType.FULL)
               resultMatch.isMatch shouldBe true
             }
           }

--- a/test/uk/gov/hmrc/brm/services/MatchingServiceSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/MatchingServiceSpec.scala
@@ -29,6 +29,8 @@ import uk.gov.hmrc.brm.utils.TestHelper._
 import uk.gov.hmrc.brm.utils.{BirthRegisterCountry, MatchingType}
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
+import play.api.test.FakeApplication
+
 
 
 class MatchingServiceConfigSpec extends UnitSpec with MockitoSugar with BeforeAndAfterAll {
@@ -232,7 +234,7 @@ class MatchingServiceSpec extends UnitSpec with MockitoSugar with BRMFakeApplica
           "ignore middle names with feature toggle enabled" should {
 
             s"($name) match when firstName argument has all middle names on input that are on the record" in {
-              running(getApp(ignoreMiddleNamesEnabled)) {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
                 val payload = Payload(reference, "Adam David", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
                 val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
@@ -240,7 +242,7 @@ class MatchingServiceSpec extends UnitSpec with MockitoSugar with BRMFakeApplica
             }
 
             s"($name) match when firstName argument has all middle names on input that on are the record, with additional spaces" in {
-              running(getApp(ignoreMiddleNamesEnabled)) {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
                 val payload = Payload(reference, " Adam    David   ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
                 val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
@@ -248,55 +250,67 @@ class MatchingServiceSpec extends UnitSpec with MockitoSugar with BRMFakeApplica
             }
 
             s"($name) match when firstName argument has all middle names on input that on are the record, with additional spaces on the record" in {
-              running(getApp(ignoreMiddleNamesEnabled)) {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
                 val payload = Payload(reference, "Adam David", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
                 val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
               }
             }
 
-            s"($name) match when firstName argument has middle names with punctuation, with additional names on record" in running(getApp(ignoreMiddleNamesEnabled)) {
-              val payload = Payload(reference, "   Jamie  Mary-Ann'é ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpacesAndPunctuation), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
+            s"($name) match when firstName argument has middle names with punctuation, with additional names on record" in {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                val payload = Payload(reference, "   Jamie  Mary-Ann'é ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpacesAndPunctuation), MatchingType.FULL)
+                resultMatch.isMatch shouldBe true
+              }
             }
 
-            s"($name) match when firstName argument has no middle names on input that are on the record" in running(getApp(ignoreMiddleNamesEnabled)) {
-              val payload = Payload(reference, "Adam", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
+            s"($name) match when firstName argument has no middle names on input that are on the record" in {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                val payload = Payload(reference, "Adam", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                resultMatch.isMatch shouldBe true
+              }
             }
 
-            s"($name) match when firstName argument has no middle names on input that are on the record, with additional spaces" in running(getApp(ignoreMiddleNamesEnabled)) {
-              val payload = Payload(reference, "    Adam     ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
+            s"($name) match when firstName argument has no middle names on input that are on the record, with additional spaces" in {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                val payload = Payload(reference, "    Adam     ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                resultMatch.isMatch shouldBe true
+              }
             }
 
-            s"($name) not match when firstName argument has too many names not on the record" in running(getApp(ignoreMiddleNamesEnabled)) {
-              val payload = Payload(reference, "Adam David James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
+            s"($name) not match when firstName argument has too many names not on the record" in {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                val payload = Payload(reference, "Adam David James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                resultMatch.isMatch shouldBe false
+              }
             }
 
-            s"($name) not match when firstName argument has too many names not on the record, with additional spaces" in running(getApp(ignoreMiddleNamesEnabled)) {
-              val payload = Payload(reference, "   Adam  David     James  ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
+            s"($name) not match when firstName argument has too many names not on the record, with additional spaces" in {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                val payload = Payload(reference, "   Adam  David     James  ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                resultMatch.isMatch shouldBe false
+              }
             }
 
           }
 
           "not ignore middle names with feature toggle disabled" should {
 
-            s"($name) match when firstName argument has all middle names on input that are on the record" in running(getApp(ignoreMiddleNamesDisabled)) {
-              val payload = Payload(reference, "Adam David", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
+            s"($name) match when firstName argument has all middle names on input that are on the record" in {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
+                val payload = Payload(reference, "Adam David", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                resultMatch.isMatch shouldBe true
+              }
             }
 
             s"($name) match when firstName argument has all middle names on input that on are the record, with additional spaces" in {
-              running(getApp(ignoreMiddleNamesEnabled)) {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
                 val payload = Payload(reference, " Adam    David   ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
                 val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
@@ -304,181 +318,237 @@ class MatchingServiceSpec extends UnitSpec with MockitoSugar with BRMFakeApplica
             }
 
             s"($name) match when firstName argument has all middle names on input that on are the record, with additional spaces on the record" in {
-              running(getApp(ignoreMiddleNamesEnabled)) {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
                 val payload = Payload(reference, "Adam David", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
                 val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
               }
             }
 
-            s"($name) not match when firstName argument has middle names with punctuation, with additional names on record" in running(getApp(ignoreMiddleNamesDisabled)) {
-              val payload = Payload(reference, "   Jamie  Mary-Ann'é ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpacesAndPunctuation), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
+            s"($name) not match when firstName argument has middle names with punctuation, with additional names on record" in {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
+                val payload = Payload(reference, "   Jamie  Mary-Ann'é ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpacesAndPunctuation), MatchingType.FULL)
+                resultMatch.isMatch shouldBe false
+              }
             }
 
-            s"($name) not match when firstName argument has no middle names on input that are on the record" in running(getApp(ignoreMiddleNamesDisabled)) {
-              val payload = Payload(reference, "Adam", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
+            s"($name) not match when firstName argument has no middle names on input that are on the record" in {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
+                val payload = Payload(reference, "Adam", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                resultMatch.isMatch shouldBe false
+              }
             }
 
-            s"($name) not match when firstName argument has no middle names on input that are on the record, with additional spaces on record" in running(getApp(ignoreMiddleNamesEnabled)) {
-              val payload = Payload(reference, "Adam", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
+            s"($name) not match when firstName argument has no middle names on input that are on the record, with additional spaces on record" in {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                val payload = Payload(reference, "Adam", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
+                resultMatch.isMatch shouldBe false
+              }
             }
 
-            s"($name) not match when firstName argument has too many names not on the record" in running(getApp(ignoreMiddleNamesDisabled)) {
-              val payload = Payload(reference, "Adam David James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
+            s"($name) not match when firstName argument has too many names not on the record" in {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
+                val payload = Payload(reference, "Adam David James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                resultMatch.isMatch shouldBe false
+              }
             }
 
-            s"($name) not match when firstName argument has too many names not on the record, with additional spaces on record" in running(getApp(ignoreMiddleNamesEnabled)) {
-              val payload = Payload(reference, "Adam David James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
+            s"($name) not match when firstName argument has too many names not on the record, with additional spaces on record" in {
+              running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                val payload = Payload(reference, "Adam David James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
+                resultMatch.isMatch shouldBe false
+              }
             }
 
           }
 
           s"($name) match when firstName contains special characters" in {
-            val payload = Payload(reference, "Chris-Jame's", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecordSpecialCharactersFirstName), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris-Jame's", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordSpecialCharactersFirstName), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match when lastName contains special characters" in {
-            val payload = Payload(reference, "Chris", "Jones--Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecordSpecialCharactersLastName), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jones--Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordSpecialCharactersLastName), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match when firstName contains space" in {
-            val payload = Payload(reference, "Chris James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecordFirstNameSpace), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordFirstNameSpace), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match when lastName contains space" in {
-            val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameSpace), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameSpace), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match when firstName contains UTF-8 characters" in {
-            val payload = Payload(reference, "Chrîs", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecordUTF8FirstName), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chrîs", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordUTF8FirstName), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match when lastName contains UTF-8 characters" in {
-            val payload = Payload(reference, "Chris", "Jonéş", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecordUTF8LastName), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jonéş", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordUTF8LastName), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match for exact match on firstName and lastName and dateOfBirth on both input and record" in {
-            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match when case is different for firstName, lastName on input" in {
-            val payload = Payload(reference, "chRis", "joNes", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "chRis", "joNes", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match when case is different for firstName, lastName on record" in {
-            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(wrongCaseValidRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(wrongCaseValidRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match when case is uppercase for firstName, lastName on input" in {
-            val payload = Payload(reference, "CHRIS", "JONES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "CHRIS", "JONES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match when case is uppercase for firstName, lastName on record" in {
-            val payload = Payload(reference, "CHRIS", "JONES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecordUppercase), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "CHRIS", "JONES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordUppercase), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match when case is different for firstName on input" in {
-            val payload = Payload(reference, "chRis", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "chRis", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match when case is different for firstName on record" in {
-            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(wrongCaseFirstNameValidRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(wrongCaseFirstNameValidRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match when case is different for lastName on input" in {
-            val payload = Payload(reference, "Chris", "joNES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "joNES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) match when case is different for lastName on record" in {
-            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(wrongCaseLastNameValidRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe true
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(wrongCaseLastNameValidRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
           }
 
           s"($name) not match when firstName and lastName are different on the input" in {
-            val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe false
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe false
+            }
           }
 
           s"($name) not match when firstName and lastName are different on the record" in {
-            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(invalidRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe false
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(invalidRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe false
+            }
           }
 
           s"($name) not match when firstName is different on input" in {
-            val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe false
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe false
+            }
           }
 
           s"($name) not match when firstName is different on record" in {
-            val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(firstNameNotMatchedRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe false
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(firstNameNotMatchedRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe false
+            }
           }
 
           s"($name) not match when lastName is different on input" in {
-            val payload = Payload(reference, "Chris", "Jone", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe false
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jone", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe false
+            }
           }
 
           s"($name) not match when lastName is different on record" in {
-            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(lastNameNotMatchRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe false
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(lastNameNotMatchRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe false
+            }
           }
 
           s"($name) not match when dateOfBirth is different on input" in {
-            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-15"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe false
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-15"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe false
+            }
           }
 
           s"($name) not match when dateOfBirth is different on record" in {
-            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-15"), BirthRegisterCountry.ENGLAND)
-            val resultMatch = MatchingService.performMatch(payload, List(dobNotMatchRecord), MatchingType.FULL)
-            resultMatch.isMatch shouldBe false
+            running(FakeApplication()) {
+              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-15"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(dobNotMatchRecord), MatchingType.FULL)
+              resultMatch.isMatch shouldBe false
+            }
           }
         }
       )

--- a/test/uk/gov/hmrc/brm/services/MatchingServiceSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/MatchingServiceSpec.scala
@@ -311,24 +311,6 @@ class MatchingServiceSpec extends UnitSpec with MockitoSugar with BRMFakeApplica
               }
             }
 
-            s"($name) not match when firstName argument has middle names with punctuation, with additional names on record" in running(getApp(ignoreMiddleNamesDisabled)) {
-              val payload = Payload(reference, "   Jamie  Mary-Ann'é ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpacesAndPunctuation), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
-            }
-
-            s"($name) not match when firstName argument has no middle names on input that are on the record" in running(getApp(ignoreMiddleNamesDisabled)) {
-              val payload = Payload(reference, "Adam", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
-            }
-
-            s"($name) not match when firstName argument has no middle names on input that are on the record, with additional spaces on record" in running(getApp(ignoreMiddleNamesEnabled)) {
-              val payload = Payload(reference, "Adam", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
-            }
-
             s"($name) not match when firstName argument has too many names not on the record" in running(getApp(ignoreMiddleNamesDisabled)) {
               val payload = Payload(reference, "Adam David James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
               val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)

--- a/test/uk/gov/hmrc/brm/services/MatchingServiceSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/MatchingServiceSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers._
+import uk.gov.hmrc.brm.BaseConfig
 import uk.gov.hmrc.brm.config.BrmConfig
 import uk.gov.hmrc.brm.models.brm.Payload
 import uk.gov.hmrc.brm.utils.TestHelper._
@@ -32,25 +33,25 @@ import uk.gov.hmrc.play.test.UnitSpec
 
 class MatchingServiceConfigSpec extends UnitSpec with MockitoSugar with BeforeAndAfterAll {
 
-  val configFirstName: Map[String, _] = Map(
+  val configFirstName: Map[String, _] = BaseConfig.config ++ Map(
     "microservice.services.birth-registration-matching.matching.firstName" -> true,
     "microservice.services.birth-registration-matching.matching.lastName" -> false,
     "microservice.services.birth-registration-matching.matching.dateOfBirth" -> false
   )
 
-  val configLastName: Map[String, _] = Map(
+  val configLastName: Map[String, _] = BaseConfig.config ++ Map(
     "microservice.services.birth-registration-matching.matching.firstName" -> false,
     "microservice.services.birth-registration-matching.matching.lastName" -> true,
     "microservice.services.birth-registration-matching.matching.dateOfBirth" -> false
   )
 
-  val configDob: Map[String, _] = Map(
+  val configDob: Map[String, _] = BaseConfig.config ++ Map(
     "microservice.services.birth-registration-matching.matching.firstName" -> false,
     "microservice.services.birth-registration-matching.matching.lastName" -> false,
     "microservice.services.birth-registration-matching.matching.dateOfBirth" -> true
   )
 
-  val configFirstNameLastName: Map[String, _] = Map(
+  val configFirstNameLastName: Map[String, _] = BaseConfig.config ++ Map(
     "microservice.services.birth-registration-matching.matching.firstName" -> true,
     "microservice.services.birth-registration-matching.matching.lastName" -> true,
     "microservice.services.birth-registration-matching.matching.dateOfBirth" -> false
@@ -63,82 +64,89 @@ class MatchingServiceConfigSpec extends UnitSpec with MockitoSugar with BeforeAn
   val dobApp = GuiceApplicationBuilder(disabled = Seq(classOf[com.kenshoo.play.metrics.PlayModule])).configure(configDob).build()
   val firstNameLastNameApp = GuiceApplicationBuilder(disabled = Seq(classOf[com.kenshoo.play.metrics.PlayModule])).configure(configFirstNameLastName).build()
 
-  "valid payload and valid Record with reference " should {
 
-    "return true result for firstName only match for partial matching" in running(
-      firstNameApp
-    ) {
-      val payload = Payload(Some("123456789"), "Chris", "wrongLastName", new LocalDate("2008-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
-      BrmConfig.matchLastName shouldBe false
-      resultMatch.isMatch shouldBe true
+  "Partial Matching (feature switch turned off)" when {
+
+    "match with reference" should {
+
+      "return true result for firstName only" in running(
+        firstNameApp
+      ) {
+        val payload = Payload(Some("123456789"), "Chris", "wrongLastName", new LocalDate("2008-02-16"), BirthRegisterCountry.ENGLAND)
+        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        BrmConfig.matchLastName shouldBe false
+        resultMatch.isMatch shouldBe true
+      }
+
+      "return true result for lastName only" in running(
+        lastNameApp
+      ) {
+        val payload = Payload(Some("123456789"), "wrongFirstName", "Jones", new LocalDate("2008-02-16"), BirthRegisterCountry.ENGLAND)
+        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        BrmConfig.matchFirstName shouldBe false
+        BrmConfig.matchDateOfBirth shouldBe false
+        resultMatch.isMatch shouldBe true
+      }
+
+      "return true result for date of birth only" in running(
+        dobApp
+      ) {
+        val payload = Payload(Some("123456789"), "wrongFirstName", "wrongLastName", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        BrmConfig.matchFirstName shouldBe false
+        resultMatch.isMatch shouldBe true
+      }
+
+      "return true result for firstName and LastName only" in running(
+        firstNameLastNameApp
+      ) {
+        val payload = Payload(Some("123456789"), "chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        resultMatch.isMatch shouldBe true
+      }
+
     }
 
-    "return true result for lastName only match for partial matching" in running(
-      lastNameApp
-    ) {
-      val payload = Payload(Some("123456789"), "wrongFirstName", "Jones", new LocalDate("2008-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
-      BrmConfig.matchFirstName shouldBe false
-      BrmConfig.matchDateOfBirth shouldBe false
-      resultMatch.isMatch shouldBe true
+    "match without reference" should {
+
+      "return true result for firstName only" in running(
+        firstNameApp
+      ) {
+        val payload = Payload(None, "Chris", "wrongLastName", new LocalDate("2008-02-16"), BirthRegisterCountry.ENGLAND)
+        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        BrmConfig.matchLastName shouldBe false
+        resultMatch.isMatch shouldBe true
+      }
+
+      "return true result for lastName only" in running(
+        lastNameApp
+      ) {
+        val payload = Payload(None, "wrongFirstName", "Jones", new LocalDate("2008-02-16"), BirthRegisterCountry.ENGLAND)
+        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        BrmConfig.matchFirstName shouldBe false
+        BrmConfig.matchDateOfBirth shouldBe false
+        resultMatch.isMatch shouldBe true
+      }
+
+      "return true result for date of birth only" in running(
+        dobApp
+      ) {
+        val payload = Payload(None, "wrongFirstName", "wrongLastName", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        BrmConfig.matchFirstName shouldBe false
+        resultMatch.isMatch shouldBe true
+      }
+
+      "return true result for firstName and LastName only" in running(
+        firstNameLastNameApp
+      ) {
+        val payload = Payload(None, "chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        resultMatch.isMatch shouldBe true
+      }
+
     }
 
-    "return true result for date of birth only match for partial matching" in running(
-      dobApp
-    ) {
-      val payload = Payload(Some("123456789"), "wrongFirstName", "wrongLastName", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
-      BrmConfig.matchFirstName shouldBe false
-      resultMatch.isMatch shouldBe true
-    }
-
-    "return true result for firstName and LastName only match for partial matching" in running(
-      firstNameLastNameApp
-    ) {
-      val payload = Payload(Some("123456789"), "chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
-      resultMatch.isMatch shouldBe true
-    }
-  }
-
-  "valid payload and valid Record with childs details" should {
-
-    "return true result for firstName only match for partial matching" in running(
-      firstNameApp
-    ) {
-      val payload = Payload(None, "Chris", "wrongLastName", new LocalDate("2008-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
-      BrmConfig.matchLastName shouldBe false
-      resultMatch.isMatch shouldBe true
-    }
-
-    "return true result for lastName only match for partial matching" in running(
-      lastNameApp
-    ) {
-      val payload = Payload(None, "wrongFirstName", "Jones", new LocalDate("2008-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
-      BrmConfig.matchFirstName shouldBe false
-      BrmConfig.matchDateOfBirth shouldBe false
-      resultMatch.isMatch shouldBe true
-    }
-
-    "return true result for date of birth only match for partial matching" in running(
-      dobApp
-    ) {
-      val payload = Payload(None, "wrongFirstName", "wrongLastName", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
-      BrmConfig.matchFirstName shouldBe false
-      resultMatch.isMatch shouldBe true
-    }
-
-    "return true result for firstName and LastName only match for partial matching" in running(
-      firstNameLastNameApp
-    ) {
-      val payload = Payload(None, "chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
-      resultMatch.isMatch shouldBe true
-    }
   }
 
 }
@@ -147,153 +155,232 @@ class MatchingServiceSpec extends UnitSpec with OneAppPerSuite with MockitoSugar
 
   implicit val hc = HeaderCarrier()
 
-  "config file contains valid keys" should {
+  "configuring" should {
 
-    "match-on-multiple should be an instance of Boolean" in {
+    "set match-on-multiple switch" in {
       MatchingService.matchOnMultiple.isInstanceOf[Boolean] shouldBe true
     }
   }
 
-  "when match-on-multiple is set to true" should {
+  "Matching" when {
 
-    object MockMatchingService extends MatchingService {
-      override val matchOnMultiple = true
+    /*
+      Multiple records
+      Currently always returning false as we don't iterate over multiple records
+     */
+
+    "multiple records" should {
+
+      object MockMatchingService extends MatchingService {
+        override val matchOnMultiple = true
+      }
+
+      "should return true if a minimum of one record matches" in {
+        val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+        val resultMatch = MockMatchingService.performMatch(payload, List(invalidRecord, validRecord), MatchingType.FULL)
+        resultMatch.isMatch shouldBe true
+      }
+
+      "return false if no records match" in {
+        val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+        val resultMatch = MockMatchingService.performMatch(payload, List(invalidRecord, invalidRecord), MatchingType.FULL)
+        resultMatch.isMatch shouldBe false
+      }
+
+      "return false result match when List is empty" in {
+        val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+        val resultMatch = MockMatchingService.performMatch(payload, List(), MatchingType.FULL)
+        resultMatch.isMatch shouldBe false
+      }
+
+      "return false result match when List contains duplicate matches" ignore {
+        val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+        val resultMatch = MockMatchingService.performMatch(payload, List(validRecord, validRecord, validRecord), MatchingType.FULL)
+        resultMatch.isMatch shouldBe false
+      }
+
     }
 
-    "should return true if a minimum of one record matches" in {
-      val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MockMatchingService.performMatch(payload, List(invalidRecord, validRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe true
-    }
+    /*
+      Single record
 
-    "return false if no records match" in {
-      val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MockMatchingService.performMatch(payload, List(invalidRecord, invalidRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe false
-    }
+      - Exact match
+      - Camel case matching
+      - Lower case matching
+      - Upper case on input matching
+      - Upper case on record matching
+     */
 
-    "return false result match when List is empty" in {
-      val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MockMatchingService.performMatch(payload, List(), MatchingType.FULL)
-      resultMatch.isMatch shouldBe false
-    }
+    "matching a single record" should {
 
-    "return false result match when List contains duplicate matches" ignore {
-      val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MockMatchingService.performMatch(payload, List(validRecord, validRecord, validRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe false
-    }
+      val references = List(Some("123456789"), None)
 
-  }
+      references.foreach(
+        reference => {
 
-  "valid request payload and valid Record with reference" should {
+          val name = reference match { case Some(x) => "with reference" case None => "without reference" }
 
-    "return true result match" in {
-      val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe true
-    }
+          "when ignoring middle names" when {
 
-    "return true when case is different for firstname, lastname" in {
-      val payload = Payload(Some("123456789"), "chRis", "joNes", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe true
-    }
+            s"($name) match when firstName argument has all middle names on input that are on the record" in {
+              val payload = Payload(reference, "Adam David", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
 
+            s"($name) match when firstName argument has no middle names on input that are on the record" in {
+              val payload = Payload(reference, "Adam", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
 
-    "return true when case is different for firstName only" in {
-      val payload = Payload(Some("123456789"), "chRis", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe true
-    }
+            s"($name) not match when firstName argument has too many names not on the record" in {
+              val payload = Payload(reference, "Adam David James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+              val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+              resultMatch.isMatch shouldBe true
+            }
 
-    "return true when case is different for lastName only" in {
-      val payload = Payload(Some("123456789"), "Chris", "joNES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe true
-    }
-  }
+          }
 
-  "valid request payload and invalid Record with reference " should {
+          s"($name) match when firstName contains special characters" in {
+            val payload = Payload(reference, "Chris-Jame's", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecordSpecialCharactersFirstName), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-    "return false result match" in {
-      val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(invalidRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe false
-    }
+          s"($name) match when lastName contains special characters" in {
+            val payload = Payload(reference, "Chris", "Jones--Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecordSpecialCharactersLastName), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-    "return false when firstName not match" in {
-      val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(firstNameNotMatchedRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe false
-    }
+          s"($name) match when firstName contains space" in {
+            val payload = Payload(reference, "Chris James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecordFirstNameSpace), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-    "return false when lastName not match" in {
-      val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(lastNameNotMatchRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe false
-    }
+          s"($name) match when lastName contains space" in {
+            val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameSpace), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-    "return false when dob not match" in {
-      val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(dobNotMatchRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe false
-    }
+          s"($name) match when firstName contains UTF-8 characters" in {
+            val payload = Payload(reference, "Chrîs", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecordUTF8FirstName), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-  }
+          s"($name) match when lastName contains UTF-8 characters" in {
+            val payload = Payload(reference, "Chris", "Jonéş", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecordUTF8LastName), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-  "valid request payload and valid Record with child details" should {
+          s"($name) match for exact match on firstName and lastName and dateOfBirth on both input and record" in {
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-    "return true result match" in {
-      val payload = Payload(None, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe true
-    }
+          s"($name) match when case is different for firstName, lastName on input" in {
+            val payload = Payload(reference, "chRis", "joNes", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-    "return true when case is different for firstname, lastname" in {
-      val payload = Payload(None, "chRis", "joNes", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe true
-    }
+          s"($name) match when case is different for firstName, lastName on record" in {
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(wrongCaseValidRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
+          s"($name) match when case is uppercase for firstName, lastName on input" in {
+            val payload = Payload(reference, "CHRIS", "JONES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-    "return true when case is different for firstName only" in {
-      val payload = Payload(None, "chRis", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe true
-    }
+          s"($name) match when case is uppercase for firstName, lastName on record" in {
+            val payload = Payload(reference, "CHRIS", "JONES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecordUppercase), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-    "return true when case is different for lastName only" in {
-      val payload = Payload(None, "Chris", "joNES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe true
-    }
-  }
+          s"($name) match when case is different for firstName on input" in {
+            val payload = Payload(reference, "chRis", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-  "valid request payload and invalid Record with child details " should {
+          s"($name) match when case is different for firstName on record" in {
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(wrongCaseFirstNameValidRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-    "return false result match" in {
-      val payload = Payload(None, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(invalidRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe false
-    }
+          s"($name) match when case is different for lastName on input" in {
+            val payload = Payload(reference, "Chris", "joNES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-    "return false when firstName not match" in {
-      val payload = Payload(None, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(firstNameNotMatchedRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe false
-    }
+          s"($name) match when case is different for lastName on record" in {
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(wrongCaseLastNameValidRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
 
-    "return false when lastName not match" in {
-      val payload = Payload(None, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(lastNameNotMatchRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe false
-    }
+          s"($name) not match when firstName and lastName are different on the input" in {
+            val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
 
-    "return false when dob not match" in {
-      val payload = Payload(None, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-      val resultMatch = MatchingService.performMatch(payload, List(dobNotMatchRecord), MatchingType.FULL)
-      resultMatch.isMatch shouldBe false
+          s"($name) not match when firstName and lastName are different on the record" in {
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(invalidRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+
+          s"($name) not match when firstName is different on input" in {
+            val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+
+          s"($name) not match when firstName is different on record" in {
+            val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(firstNameNotMatchedRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+
+          s"($name) not match when lastName is different on input" in {
+            val payload = Payload(reference, "Chris", "Jone", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+
+          s"($name) not match when lastName is different on record" in {
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(lastNameNotMatchRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+
+          s"($name) not match when dateOfBirth is different on input" in {
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-15"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+
+          s"($name) not match when dateOfBirth is different on record" in {
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-15"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MatchingService.performMatch(payload, List(dobNotMatchRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+        }
+      )
     }
 
   }

--- a/test/uk/gov/hmrc/brm/services/parser/NameParserSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/parser/NameParserSpec.scala
@@ -28,7 +28,7 @@ class NameParserSpec extends UnitSpec with BRMFakeApplication {
   "NameParser" should {
 
     "split a string into words removing trailing space" in {
-      val input = "Adam David      Charles       Mary-Ann'é"
+      val input = "    Adam David      Charles       Mary-Ann'é"
       val names : List[String] = input.names
 
       names.length shouldBe 4
@@ -36,6 +36,15 @@ class NameParserSpec extends UnitSpec with BRMFakeApplication {
       names(1) shouldBe "David"
       names(2) shouldBe "Charles"
       names(3) shouldBe "Mary-Ann'é"
+    }
+
+    "filter two list of names and remove additional names in the list not in the input" in {
+      val left = List("Adam", "David", "charles")
+      val right = List("Adam", "David", "Charles", "Edward")
+
+      // filter the list on the right (record) with the number of occurrances in the left
+      val names = left filter right
+
     }
 
   }

--- a/test/uk/gov/hmrc/brm/services/parser/NameParserSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/parser/NameParserSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.brm.services.parser
+
+import uk.gov.hmrc.brm.BRMFakeApplication
+import uk.gov.hmrc.brm.services.parser.NameParser._
+import uk.gov.hmrc.play.test.UnitSpec
+
+/**
+  * Created by adamconder on 02/02/2017.
+  */
+class NameParserSpec extends UnitSpec with BRMFakeApplication {
+
+  "NameParser" should {
+
+    "split a string into words removing trailing space" in {
+      val input = "Adam David      Charles       Mary-Ann'é"
+      val names : List[String] = input.names
+
+      names.length shouldBe 4
+      names.head shouldBe "Adam"
+      names(1) shouldBe "David"
+      names(2) shouldBe "Charles"
+      names(3) shouldBe "Mary-Ann'é"
+    }
+
+  }
+
+}

--- a/test/uk/gov/hmrc/brm/services/parser/NameParserSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/parser/NameParserSpec.scala
@@ -32,10 +32,10 @@ class NameParserSpec extends UnitSpec with BRMFakeApplication {
       val names : List[String] = input.names
 
       names.length shouldBe 4
-      names.head shouldBe "Adam"
-      names(1) shouldBe "David"
-      names(2) shouldBe "Charles"
-      names(3) shouldBe "Mary-Ann'é"
+      names.head shouldBe "adam"
+      names(1) shouldBe "david"
+      names(2) shouldBe "charles"
+      names(3) shouldBe "mary-ann'é"
     }
 
     "filter two list of names and remove additional names in the list not in the input" in {
@@ -44,7 +44,7 @@ class NameParserSpec extends UnitSpec with BRMFakeApplication {
 
       // filter the list on the right (record) with the number of occurrances in the left
       val names = left filter right
-
+      names should not be Nil
     }
 
   }

--- a/test/uk/gov/hmrc/brm/services/parser/NameParserSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/parser/NameParserSpec.scala
@@ -38,13 +38,79 @@ class NameParserSpec extends UnitSpec with BRMFakeApplication {
       names(3) shouldBe "mary-ann'é"
     }
 
-    "filter two list of names and remove additional names in the list not in the input" in {
-      val left = List("Adam", "David", "charles")
+    /*
+      If left is less or equal then drop elements from right
+      If left is greater then don't drop elements from right
+     */
+
+    "filter right hand side list when left has less elements" in {
+      val left = List("Adam", "David", "Charles")
       val right = List("Adam", "David", "Charles", "Edward")
 
-      // filter the list on the right (record) with the number of occurrances in the left
+      // filter the list on the right (record) with the number of occurences in the left
       val names = left filter right
       names should not be Nil
+      names shouldBe List("Adam", "David", "Charles")
+    }
+
+    "filter right hand side list when left has equal elements" in {
+      val left = List("Adam", "David", "Charles", "Edward")
+      val right = List("Adam", "David", "Charles", "Edward")
+
+      // filter the list on the right (record) with the number of occurences in the left
+      val names = left filter right
+      names should not be Nil
+      names shouldBe List("Adam", "David", "Charles", "Edward")
+    }
+
+    "not filter right hand side list when left has more elements and return right" in {
+      val left = List("Adam", "David", "Charles", "Edward")
+      val right = List("Adam", "David", "Charles")
+
+      // filter the list on the right (record) with the number of occurences in the left
+      val names = left filter right
+      names should not be Nil
+      names shouldBe List("Adam", "David", "Charles")
+    }
+
+    "not filter when left and right have zero items" in {
+      val left = Nil
+      val right = Nil
+
+      // filter the list on the right (record) with the number of occurences in the left
+      val names = left filter right
+      names shouldBe Nil
+    }
+
+    "not filter when right has zero items" in {
+      val left = List("Adam", "David")
+      val right = Nil
+
+      val names = left filter right
+      names shouldBe Nil
+    }
+
+    "not filter when left has zero items" in {
+      val left = Nil
+      val right = List("Adam", "David")
+
+      val names = left filter right
+      names shouldBe List("Adam", "David")
+    }
+
+    "Nil should build up the names into a string" in {
+      val list = Nil
+      list.listToString shouldBe ""
+    }
+
+    "List(adam, david) should build up the names into a string" in {
+      val list = List("Adam", "David")
+      list.listToString shouldBe "Adam David"
+    }
+
+    "List(adam, david, smith, test) should build up the names into a string" in {
+      val list = List("Adam", "David", "Smith", "Test")
+      list.listToString shouldBe "Adam David Smith Test"
     }
 
   }

--- a/test/uk/gov/hmrc/brm/utils/TestHelper.scala
+++ b/test/uk/gov/hmrc/brm/utils/TestHelper.scala
@@ -95,6 +95,18 @@ object TestHelper {
     Record(child, None)
   }
 
+  def validRecordMiddleNamesWithSpaces: Record ={
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "  Adam     David ", "Jones",Some(birthDate))
+    Record(child, None)
+  }
+
+  def validRecordMiddleNamesWithSpacesAndPunctuation: Record ={
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "   Jamie  Mary-Ann'é    Earl ", "Jones",Some(birthDate))
+    Record(child, None)
+  }
+
   def validRecordSpecialCharactersLastName: Record ={
     val birthDate = new LocalDate("2012-02-16")
     val child =  Child(123456789, "Chris", "Jones--Smith",Some(birthDate))

--- a/test/uk/gov/hmrc/brm/utils/TestHelper.scala
+++ b/test/uk/gov/hmrc/brm/utils/TestHelper.scala
@@ -78,36 +78,100 @@ object TestHelper {
     """.stripMargin)
 
   def validRecord: Record ={
-    var birthDate = new LocalDate("2012-02-16")
-    val  child =  Child(123456789, "Chris", "Jones",Some(birthDate))
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "Chris", "Jones",Some(birthDate))
     Record(child, None)
   }
 
+  def validRecordSpecialCharactersFirstName: Record ={
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "Chris-Jame's", "Jones",Some(birthDate))
+    Record(child, None)
+  }
+
+  def validRecordMiddleNames: Record ={
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "Adam David", "Jones",Some(birthDate))
+    Record(child, None)
+  }
+
+  def validRecordSpecialCharactersLastName: Record ={
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "Chris", "Jones--Smith",Some(birthDate))
+    Record(child, None)
+  }
+
+  def validRecordFirstNameSpace: Record ={
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "Chris James", "Jones",Some(birthDate))
+    Record(child, None)
+  }
+
+  def validRecordLastNameSpace: Record ={
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "Chris", "Jones Smith",Some(birthDate))
+    Record(child, None)
+  }
+
+  def validRecordUTF8FirstName : Record = {
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "Chrîs", "Jones",Some(birthDate))
+    Record(child, None)
+  }
+
+  def validRecordUTF8LastName : Record = {
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "Chris", "Jonéş",Some(birthDate))
+    Record(child, None)
+  }
+
+  def validRecordUppercase: Record ={
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "CHRIS", "JONES",Some(birthDate))
+    Record(child, None)
+  }
+
+  def wrongCaseFirstNameValidRecord : Record = {
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(1, "CHriS", "Jones", Some(birthDate))
+    Record(child, None)
+  }
+
+  def wrongCaseLastNameValidRecord : Record = {
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(1, "Chris", "JOnES", Some(birthDate))
+    Record(child, None)
+  }
+
+  def wrongCaseValidRecord : Record = {
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(1, "cHrIs", "JOnES", Some(birthDate))
+    Record(child, None)
+  }
 
   def invalidRecord: Record ={
-    var birthDate = new LocalDate("2012-02-16")
-    val  child =  Child(1, "invalidfirstName", "invalidLastName",None)
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(1, "invalidfirstName", "invalidLastName",None)
     Record(child, None)
   }
 
   def firstNameNotMatchedRecord: Record ={
-    var birthDate = new LocalDate("2012-02-16")
-    val  child =  Child(123456789, "Manish", "Jones",Some(birthDate))
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "Manish", "Jones",Some(birthDate))
     Record(child, None)
   }
 
   def lastNameNotMatchRecord: Record ={
-    var birthDate = new LocalDate("2012-02-16")
-    val  child =  Child(123456789, "Chris", "lastName",Some(birthDate))
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "Chris", "lastName",Some(birthDate))
     Record(child, None)
   }
 
   def dobNotMatchRecord: Record ={
-    var birthDate = new LocalDate("2012-02-16")
-    val  child =  Child(123456789, "Chris", "Jones",None)
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "Chris", "Jones",None)
     Record(child, None)
   }
-
 
   val invalidResponse = Json.parse(
     """

--- a/test/uk/gov/hmrc/brm/utils/TestHelper.scala
+++ b/test/uk/gov/hmrc/brm/utils/TestHelper.scala
@@ -125,6 +125,18 @@ object TestHelper {
     Record(child, None)
   }
 
+  def validRecordLastNameMultipleSpace: Record ={
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "Chris", "Jones  Smith",Some(birthDate))
+    Record(child, None)
+  }
+
+  def validRecordLastNameMultipleSpaceBeginningTrailing: Record ={
+    val birthDate = new LocalDate("2012-02-16")
+    val child =  Child(123456789, "Chris", "  Jones  Smith ",Some(birthDate))
+    Record(child, None)
+  }
+
   def validRecordUTF8FirstName : Record = {
     val birthDate = new LocalDate("2012-02-16")
     val child =  Child(123456789, "Chrîs", "Jones",Some(birthDate))


### PR DESCRIPTION
- Filtering out middle names on the record if the user does not provide them
- Adding implicit class to call `.names` method on string to return a `List[String]` with whitespace removed
- Adding implicit class to class `.listToString` method to return a `String` with the names concat