### PR TITLE
BRMS-248: refactoring transaction auditor

### DIFF
--- a/app/uk/gov/hmrc/brm/audit/BRMAudit.scala
+++ b/app/uk/gov/hmrc/brm/audit/BRMAudit.scala
@@ -17,6 +17,8 @@
 package uk.gov.hmrc.brm.audit
 
 import uk.gov.hmrc.brm.models.brm.Payload
+import uk.gov.hmrc.brm.models.matching.ResultMatch
+import uk.gov.hmrc.brm.models.response.Record
 import uk.gov.hmrc.brm.utils.BrmLogger
 import uk.gov.hmrc.play.audit.AuditExtensions._
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
@@ -24,7 +26,6 @@ import uk.gov.hmrc.play.audit.model.DataEvent
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
-
 /**
   * AuditEvent - Abstract class for auditing events
   * @param auditType type of audit event, given a unique identifier to search on
@@ -33,18 +34,18 @@ import scala.concurrent.Future
   * @param path endpoint path
   * @param hc implicit headerCarrier
   */
-protected abstract class AuditEvent(
-                           auditType : String,
-                           detail : Map[String, String],
-                           transactionName: String,
-                           path : String = "N/A"
-                         )(implicit hc: HeaderCarrier)
+
+abstract class AuditEvent(auditType : String,
+                          detail : Map[String, String],
+                          transactionName: String,
+                          path : String = "N/A")(implicit hc: HeaderCarrier)
   extends DataEvent(
     auditSource = "brm",
     auditType = auditType,
     detail = detail,
     tags = hc.toAuditTags(transactionName, path)
   )
+
 
 abstract class BRMAudit(connector : AuditConnector) {
 
@@ -62,6 +63,15 @@ abstract class BRMAudit(connector : AuditConnector) {
         BrmLogger.warn(super.getClass.getCanonicalName, s"event", s"event failed to audit")
         e
     }
+  }
+
+  def recordFoundAndMatchToMap(records : List[Record],
+                               matchResult : ResultMatch) = {
+    Map(
+      "recordFound" -> records.nonEmpty.toString,
+      "multipleRecords" -> {records.length > 1}.toString,
+      "birthsPerSearch" -> records.length.toString
+    ) ++ matchResult.audit
   }
 
 }

--- a/app/uk/gov/hmrc/brm/audit/BRMAudit.scala
+++ b/app/uk/gov/hmrc/brm/audit/BRMAudit.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.brm.audit
 import uk.gov.hmrc.brm.models.brm.Payload
 import uk.gov.hmrc.brm.models.matching.ResultMatch
 import uk.gov.hmrc.brm.models.response.Record
-import uk.gov.hmrc.brm.utils.BrmLogger
+import uk.gov.hmrc.brm.utils.BRMLogger
 import uk.gov.hmrc.play.audit.AuditExtensions._
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 import uk.gov.hmrc.play.audit.model.DataEvent
@@ -56,11 +56,11 @@ abstract class BRMAudit(connector : AuditConnector) {
   protected def event(event: AuditEvent) : Future[AuditResult] = {
     connector.sendEvent(event) map {
       success =>
-        BrmLogger.info(super.getClass.getCanonicalName, s"event", "event successfully audited")
+        BRMLogger.info(super.getClass.getCanonicalName, s"event", "event successfully audited")
         success
     } recover {
       case e @ AuditResult.Failure(msg, _) =>
-        BrmLogger.warn(super.getClass.getCanonicalName, s"event", s"event failed to audit")
+        BRMLogger.warn(super.getClass.getCanonicalName, s"event", s"event failed to audit")
         e
     }
   }

--- a/app/uk/gov/hmrc/brm/audit/EnglandAndWalesAudit.scala
+++ b/app/uk/gov/hmrc/brm/audit/EnglandAndWalesAudit.scala
@@ -24,6 +24,8 @@ import uk.gov.hmrc.brm.utils.CommonUtil.{DetailsRequest, ReferenceRequest}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.http.HeaderCarrier
 
+import scala.concurrent.Future
+
 /**
   * Created by adamconder on 08/02/2017.
   */
@@ -50,7 +52,7 @@ class EnglandAndWalesAudit(connector : AuditConnector = MicroserviceGlobal.audit
             event(new EnglandAndWalesAuditEvent(result, "gro-reference"))
         }
       case _ =>
-        throw new IllegalArgumentException("payload argument not specified")
+        Future.failed(new IllegalArgumentException("[EnglandAndWalesAudit] payload argument not specified"))
     }
   }
 

--- a/app/uk/gov/hmrc/brm/audit/MatchingAudit.scala
+++ b/app/uk/gov/hmrc/brm/audit/MatchingAudit.scala
@@ -19,10 +19,12 @@ package uk.gov.hmrc.brm.audit
 import com.google.inject.Singleton
 import uk.gov.hmrc.brm.config.MicroserviceGlobal
 import uk.gov.hmrc.brm.models.brm.Payload
-import uk.gov.hmrc.brm.utils.CommonUtil
+import uk.gov.hmrc.brm.utils.{BRMLogger, CommonUtil}
 import uk.gov.hmrc.brm.utils.CommonUtil.{DetailsRequest, ReferenceRequest}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.Future
 
 /**
   * Created by adamconder on 08/02/2017.
@@ -41,6 +43,7 @@ class MatchingAudit(connector : AuditConnector = MicroserviceGlobal.auditConnect
     extends AuditEvent("BRM-Matching-Results", detail = result, transactionName = "brm-match", path)
 
   def audit(result : Map[String, String], payload : Option[Payload])(implicit hc : HeaderCarrier) = {
+    BRMLogger.info("MatchingAudit", "audit", "auditing match event")
     payload match {
       case Some(p) =>
         CommonUtil.getOperationType(p) match {
@@ -50,7 +53,7 @@ class MatchingAudit(connector : AuditConnector = MicroserviceGlobal.auditConnect
             event(new MatchingEvent(result, "birth-registration-matching/match/reference"))
         }
       case _ =>
-        throw new IllegalArgumentException("payload argument not specified")
+        Future.failed(new IllegalArgumentException("[MatchingAudit] payload argument not specified"))
     }
   }
 

--- a/app/uk/gov/hmrc/brm/audit/NorthernIrelandAudit.scala
+++ b/app/uk/gov/hmrc/brm/audit/NorthernIrelandAudit.scala
@@ -24,6 +24,8 @@ import uk.gov.hmrc.brm.utils.CommonUtil.{DetailsRequest, ReferenceRequest}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.http.HeaderCarrier
 
+import scala.concurrent.Future
+
 /**
   * Created by adamconder on 08/02/2017.
   */
@@ -50,7 +52,7 @@ class NorthernIrelandAudit(connector : AuditConnector = MicroserviceGlobal.audit
             event(new NorthernIrelandAuditEvent(result, "gro-ni-reference"))
         }
       case _ =>
-        throw new IllegalArgumentException("payload argument not specified")
+        Future.failed(new IllegalArgumentException("[NorthernIreland] payload argument not specified"))
     }
 
   }

--- a/app/uk/gov/hmrc/brm/audit/ScotlandAudit.scala
+++ b/app/uk/gov/hmrc/brm/audit/ScotlandAudit.scala
@@ -24,6 +24,8 @@ import uk.gov.hmrc.brm.utils.CommonUtil.{DetailsRequest, ReferenceRequest}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.http.HeaderCarrier
 
+import scala.concurrent.Future
+
 /**
   * Created by adamconder on 08/02/2017.
   */
@@ -50,7 +52,7 @@ class ScotlandAudit(connector: AuditConnector = MicroserviceGlobal.auditConnecto
             event(new ScotlandAuditEvent(result, "nrs-reference"))
         }
       case _ =>
-        throw new IllegalArgumentException("payload argument not specified")
+        Future.failed(new IllegalArgumentException("[ScotlandAudit] payload argument not specified"))
     }
   }
 

--- a/app/uk/gov/hmrc/brm/audit/TransactionAuditor.scala
+++ b/app/uk/gov/hmrc/brm/audit/TransactionAuditor.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.brm.audit
 import com.google.inject.Singleton
 import uk.gov.hmrc.brm.config.{BrmConfig, MicroserviceGlobal}
 import uk.gov.hmrc.brm.models.brm.Payload
+import uk.gov.hmrc.brm.models.matching.ResultMatch
 import uk.gov.hmrc.brm.models.response.Record
 import uk.gov.hmrc.brm.services.parser.NameParser._
 import uk.gov.hmrc.brm.utils.CommonUtil.{DetailsRequest, ReferenceRequest}
@@ -32,9 +33,7 @@ import scala.annotation.tailrec
   * Created by adamconder on 15/02/2017.
   */
 @Singleton
-class RequestsAndResultsAudit(
-                               connector : AuditConnector = MicroserviceGlobal.auditConnector
-                             ) extends BRMAudit(connector) {
+class TransactionAuditor(connector : AuditConnector = MicroserviceGlobal.auditConnector) extends BRMAudit(connector) {
 
   /**
     * Audit event for the result of MatchingService and data submitted to the API
@@ -53,21 +52,43 @@ class RequestsAndResultsAudit(
   def audit(result : Map[String, String], payload: Option[Payload])(implicit hc : HeaderCarrier) = {
     payload match {
       case Some(p) =>
-        // concat the map result
-        val uniqueKey = Map("brmKey" -> Keygenerator.geKey())
-        val features = BrmConfig.audit
-        val payloadAudit = p.audit
-        val data = result ++ features ++ payloadAudit ++ uniqueKey
-
         CommonUtil.getOperationType(p) match {
           case DetailsRequest() =>
-            event(new RequestsAndResultsAuditEvent(data, "birth-registration-matching/match/details"))
+            event(new RequestsAndResultsAuditEvent(result, "birth-registration-matching/match/details"))
           case ReferenceRequest() =>
-            event(new RequestsAndResultsAuditEvent(data, "birth-registration-matching/match/reference"))
+            event(new RequestsAndResultsAuditEvent(result, "birth-registration-matching/match/reference"))
         }
       case _ =>
         throw new IllegalArgumentException("payload argument not specified")
     }
+  }
+
+  def transactionToMap(payload: Payload,
+                   records : List[Record],
+                   matchResult : ResultMatch): Map[String, String] = {
+
+    // get unique key
+    val uniqueKey = Map("brmKey" -> Keygenerator.geKey())
+
+    // audit match result and if a record was found
+    val matchAudit = recordFoundAndMatchToMap(records, matchResult)
+
+    // audit status on the records
+    val auditWordsPerNameOnRecords = responseWordCount(records)
+    val auditCharactersPerNameOnRecords = responseCharacterCount(records)
+
+    // audit application feature switches
+    val features = BrmConfig.audit
+
+    // audit payload
+    val payloadAudit = payload.audit
+
+    features ++
+      payloadAudit ++
+      uniqueKey ++
+      auditWordsPerNameOnRecords ++
+      auditCharactersPerNameOnRecords ++
+      matchAudit
   }
 
   def responseWordCount(record: List[Record]): Map[String, String] = {

--- a/app/uk/gov/hmrc/brm/audit/TransactionAuditor.scala
+++ b/app/uk/gov/hmrc/brm/audit/TransactionAuditor.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.brm.models.matching.ResultMatch
 import uk.gov.hmrc.brm.models.response.Record
 import uk.gov.hmrc.brm.services.parser.NameParser._
 import uk.gov.hmrc.brm.utils.CommonUtil.{DetailsRequest, ReferenceRequest}
-import uk.gov.hmrc.brm.utils.{CommonUtil, Keygenerator}
+import uk.gov.hmrc.brm.utils.{CommonUtil, KeyGenerator}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.http.HeaderCarrier
 
@@ -68,7 +68,7 @@ class TransactionAuditor(connector : AuditConnector = MicroserviceGlobal.auditCo
                    matchResult : ResultMatch): Map[String, String] = {
 
     // get unique key
-    val uniqueKey = Map("brmKey" -> Keygenerator.geKey())
+    val uniqueKey = Map("brmKey" -> KeyGenerator.getKey())
 
     // audit match result and if a record was found
     val matchAudit = recordFoundAndMatchToMap(records, matchResult)

--- a/app/uk/gov/hmrc/brm/audit/TransactionAuditor.scala
+++ b/app/uk/gov/hmrc/brm/audit/TransactionAuditor.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.annotation.tailrec
+import scala.concurrent.Future
 
 /**
   * Created by adamconder on 15/02/2017.
@@ -59,7 +60,7 @@ class TransactionAuditor(connector : AuditConnector = MicroserviceGlobal.auditCo
             event(new RequestsAndResultsAuditEvent(result, "birth-registration-matching/match/reference"))
         }
       case _ =>
-        throw new IllegalArgumentException("payload argument not specified")
+        Future.failed(new IllegalArgumentException("[TransactionAuditor] payload argument not specified"))
     }
   }
 

--- a/app/uk/gov/hmrc/brm/connectors/BirthConnector.scala
+++ b/app/uk/gov/hmrc/brm/connectors/BirthConnector.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.brm.connectors
 
 import play.api.libs.json.JsValue
 import uk.gov.hmrc.brm.models.brm.Payload
-import uk.gov.hmrc.brm.utils.BrmLogger
+import uk.gov.hmrc.brm.utils.BRMLogger
 import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.play.http._
 
@@ -57,13 +57,13 @@ trait BirthConnector extends ServicesConfig {
   }
 
   def getReference(payload: Payload)(implicit hc: HeaderCarrier) = {
-    BrmLogger.info(s"BirthConnector", "getReference", "calling request with reference number")
+    BRMLogger.info(s"BirthConnector", "getReference", "calling request with reference number")
     val requestData = buildRequest(payload, ReferenceRequest())
     sendRequest(requestData)
   }
 
   def getChildDetails(payload: Payload)(implicit hc: HeaderCarrier) = {
-    BrmLogger.info(s"BirthConnector", "getChildDetails", "calling request with child details")
+    BRMLogger.info(s"BirthConnector", "getChildDetails", "calling request with child details")
     val requestData = buildRequest(payload, DetailsRequest())
     sendRequest(requestData)
   }

--- a/app/uk/gov/hmrc/brm/connectors/GROConnector.scala
+++ b/app/uk/gov/hmrc/brm/connectors/GROConnector.scala
@@ -20,7 +20,7 @@ import com.google.inject.Singleton
 import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.brm.config.WSHttp
 import uk.gov.hmrc.brm.models.brm.Payload
-import uk.gov.hmrc.brm.utils.{BrmLogger, Keygenerator, NameFormat}
+import uk.gov.hmrc.brm.utils.{BRMLogger, KeyGenerator, NameFormat}
 import uk.gov.hmrc.play.http.HttpPost
 
 /**
@@ -36,7 +36,7 @@ class GROConnector(var httpPost: HttpPost = WSHttp) extends BirthConnector {
   private val referenceUri = s"$serviceUrl/$baseUri/match/reference"
 
   override val headers = Seq(
-    BrmLogger.BRM_KEY -> Keygenerator.geKey(),
+    BRMLogger.BRM_KEY -> KeyGenerator.getKey(),
     "Content-Type" -> "application/json; charset=utf-8")
 
   override val referenceBody: PartialFunction[Payload, (String, JsValue)] = {

--- a/app/uk/gov/hmrc/brm/connectors/GRONIConnector.scala
+++ b/app/uk/gov/hmrc/brm/connectors/GRONIConnector.scala
@@ -17,12 +17,11 @@
 package uk.gov.hmrc.brm.connectors
 
 import com.google.inject.Singleton
-import org.joda.time.LocalDate
 import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.brm.audit.NorthernIrelandAudit
 import uk.gov.hmrc.brm.config.WSHttp
 import uk.gov.hmrc.brm.models.brm.Payload
-import uk.gov.hmrc.brm.utils.{BirthRegisterCountry, BrmLogger}
+import uk.gov.hmrc.brm.utils.BRMLogger
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpPost, NotImplementedException}
 
 import scala.concurrent.Future
@@ -31,7 +30,7 @@ import scala.concurrent.Future
   * Created by adamconder on 07/02/2017.
   */
 @Singleton
-class GRONIConnector(var httpPost: HttpPost = WSHttp) extends BirthConnector {
+class GRONIConnector(var httpPost: HttpPost = WSHttp, auditor : NorthernIrelandAudit = new NorthernIrelandAudit()) extends BirthConnector {
 
   override val serviceUrl = ""
   private val baseUri = ""
@@ -57,23 +56,23 @@ class GRONIConnector(var httpPost: HttpPost = WSHttp) extends BirthConnector {
   }
 
   override def getReference(payload: Payload)(implicit hc: HeaderCarrier) = {
-    BrmLogger.debug(s"NRSConnector", "getChildDetails", s"requesting child's record from GRO-NI")
+    BRMLogger.debug(s"NRSConnector", "getChildDetails", s"requesting child's record from GRO-NI")
 
     referenceBody.apply(payload)
 
     val result: Map[String, String] = Map("match" -> "false")
-    new NorthernIrelandAudit().audit(result, Some(payload))
+    auditor.audit(result, Some(payload))
 
     Future.failed(new NotImplementedException("No getReference method available for GRONI connector."))
   }
 
   override def getChildDetails(payload: Payload)(implicit hc: HeaderCarrier) = {
-    BrmLogger.debug(s"NRSConnector", "getChildDetails", s"requesting child's record from GRO-NI")
+    BRMLogger.debug(s"NRSConnector", "getChildDetails", s"requesting child's record from GRO-NI")
 
     detailsBody.apply(payload)
 
     val result: Map[String, String] = Map("match" -> "false")
-    new NorthernIrelandAudit().audit(result, Some(payload))
+    auditor.audit(result, Some(payload))
 
     Future.failed(new NotImplementedException("No getChildDetails method available for GRONI connector."))
   }

--- a/app/uk/gov/hmrc/brm/connectors/NRSConnector.scala
+++ b/app/uk/gov/hmrc/brm/connectors/NRSConnector.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.brm.audit.ScotlandAudit
 import uk.gov.hmrc.brm.config.WSHttp
 import uk.gov.hmrc.brm.models.brm.Payload
-import uk.gov.hmrc.brm.utils.BrmLogger
+import uk.gov.hmrc.brm.utils.BRMLogger
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpPost, NotImplementedException}
 
 import scala.concurrent.Future
@@ -30,7 +30,7 @@ import scala.concurrent.Future
   * Created by adamconder on 07/02/2017.
   */
 @Singleton
-class NRSConnector(var httpPost: HttpPost = WSHttp) extends BirthConnector {
+class NRSConnector(var httpPost: HttpPost = WSHttp, auditor : ScotlandAudit = new ScotlandAudit()) extends BirthConnector {
 
   override val serviceUrl = ""
   private val baseUri = ""
@@ -56,23 +56,23 @@ class NRSConnector(var httpPost: HttpPost = WSHttp) extends BirthConnector {
   }
 
   override def getReference(payload: Payload)(implicit hc: HeaderCarrier) = {
-    BrmLogger.debug(s"NRSConnector", "getReference", s"requesting child's record from NRS")
+    BRMLogger.debug(s"NRSConnector", "getReference", s"requesting child's record from NRS")
 
     referenceBody.apply(payload)
 
     val result: Map[String, String] = Map("match" -> "false")
-    new ScotlandAudit().audit(result, Some(payload))
+    auditor.audit(result, Some(payload))
 
     Future.failed(new NotImplementedException("No getReference method available for NRS connector."))
   }
 
   override def getChildDetails(payload: Payload)(implicit hc: HeaderCarrier) = {
-    BrmLogger.debug(s"NRSConnector", "getReference", s"requesting child's record from NRS")
+    BRMLogger.debug(s"NRSConnector", "getReference", s"requesting child's record from NRS")
 
     detailsBody.apply(payload)
 
     val result: Map[String, String] = Map("match" -> "false")
-    new ScotlandAudit().audit(result, Some(payload))
+    auditor.audit(result, Some(payload))
 
     Future.failed(new NotImplementedException("No getChildDetails method available for NRS connector."))
   }

--- a/app/uk/gov/hmrc/brm/controllers/BRMBaseController.scala
+++ b/app/uk/gov/hmrc/brm/controllers/BRMBaseController.scala
@@ -30,6 +30,9 @@ trait BRMBaseController extends BaseController with BrmException {
   lazy val contentType: String = "application/json; charset=utf-8"
   lazy val headers: (String, String)  = (ACCEPT, "application/vnd.hmrc.1.0+json")
 
+  protected val transactionAuditor : TransactionAuditor
+  protected val matchingAuditor : MatchingAudit
+
   def respond(response: Result): Result = {
     response
       .as(contentType)
@@ -61,15 +64,15 @@ trait BRMBaseController extends BaseController with BrmException {
 
     val matchResult = ResultMatch(Bad(), Bad(), Bad(), Bad())
 
-    // TODO stub out this or DI it
+    // TODO stub out this or D
     // audit matching result
-    new MatchingAudit().audit(matchResult.audit, Some(payload))
+    matchingAuditor.audit(matchResult.audit, Some(payload))
 
     // MetricsFactory auditor
     auditor.audit(auditor.recordFoundAndMatchToMap(Nil, matchResult), Some(payload))
 
     // audit transaction
-    new TransactionAuditor().transactionToMap(payload, Nil, matchResult)
+    transactionAuditor.transactionToMap(payload, Nil, matchResult)
   }
 
 }

--- a/app/uk/gov/hmrc/brm/controllers/BRMBaseController.scala
+++ b/app/uk/gov/hmrc/brm/controllers/BRMBaseController.scala
@@ -64,7 +64,6 @@ trait BRMBaseController extends BaseController with BrmException {
 
     val matchResult = ResultMatch(Bad(), Bad(), Bad(), Bad())
 
-    // TODO stub out this or D
     // audit matching result
     matchingAuditor.audit(matchResult.audit, Some(payload))
 
@@ -72,7 +71,7 @@ trait BRMBaseController extends BaseController with BrmException {
     auditor.audit(auditor.recordFoundAndMatchToMap(Nil, matchResult), Some(payload))
 
     // audit transaction
-    transactionAuditor.transactionToMap(payload, Nil, matchResult)
+    transactionAuditor.audit(transactionAuditor.transactionToMap(payload, Nil, matchResult), Some(payload))
   }
 
 }

--- a/app/uk/gov/hmrc/brm/controllers/BRMBaseController.scala
+++ b/app/uk/gov/hmrc/brm/controllers/BRMBaseController.scala
@@ -61,6 +61,7 @@ trait BRMBaseController extends BaseController with BrmException {
 
     val matchResult = ResultMatch(Bad(), Bad(), Bad(), Bad())
 
+    // TODO stub out this or DI it
     // audit matching result
     new MatchingAudit().audit(matchResult.audit, Some(payload))
 

--- a/app/uk/gov/hmrc/brm/controllers/BirthEventsController.scala
+++ b/app/uk/gov/hmrc/brm/controllers/BirthEventsController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.brm.controllers
 
 import play.api.libs.json._
-import uk.gov.hmrc.brm.audit.{BRMAudit, TransactionAuditor, WhereBirthRegisteredAudit}
+import uk.gov.hmrc.brm.audit.{BRMAudit, WhereBirthRegisteredAudit}
 import uk.gov.hmrc.brm.implicits.Implicits.{AuditFactory, MetricsFactory}
 import uk.gov.hmrc.brm.metrics.BRMMetrics
 import uk.gov.hmrc.brm.models.brm.Payload

--- a/app/uk/gov/hmrc/brm/implicits/Implicits.scala
+++ b/app/uk/gov/hmrc/brm/implicits/Implicits.scala
@@ -16,11 +16,11 @@
 
 package uk.gov.hmrc.brm.implicits
 
+import com.google.inject.Singleton
 import uk.gov.hmrc.brm.audit.{BRMAudit, EnglandAndWalesAudit, NorthernIrelandAudit, ScotlandAudit}
 import uk.gov.hmrc.brm.metrics._
 import uk.gov.hmrc.brm.models.brm.Payload
 import uk.gov.hmrc.brm.utils.BirthRegisterCountry
-import uk.gov.hmrc.brm.utils.BirthRegisterCountry._
 
 object Implicits {
 
@@ -51,7 +51,8 @@ object Implicits {
 
   }
 
-  object AuditFactory {
+  @Singleton
+  class AuditFactory() {
 
     private lazy val set : Map[BirthRegisterCountry.Value, BRMAudit] = Map(
       BirthRegisterCountry.ENGLAND -> new EnglandAndWalesAudit(),

--- a/app/uk/gov/hmrc/brm/metrics/Metrics.scala
+++ b/app/uk/gov/hmrc/brm/metrics/Metrics.scala
@@ -94,7 +94,6 @@ object GRONIMetrics extends BRMMetrics {
 /**
   * APIVersionMetrics
   * @param version api version used for this service
-  * TODO this should inherit off CountingMetric
   */
 
 case class APIVersionMetrics(version :String) extends BRMMetrics {
@@ -106,7 +105,6 @@ case class APIVersionMetrics(version :String) extends BRMMetrics {
 /**
   * AuditSourceMetrics
   * @param auditSource name of the client making the request to this service
-  * TODO this should inherit off CountingMetric
   */
 
 case class AuditSourceMetrics (auditSource :String) extends BRMMetrics {

--- a/app/uk/gov/hmrc/brm/services/LookupService.scala
+++ b/app/uk/gov/hmrc/brm/services/LookupService.scala
@@ -34,6 +34,7 @@ object LookupService extends LookupService {
   override val nrsConnector = new NRSConnector
   override val groniConnector = new GRONIConnector
   override val matchingService = MatchingService
+  override val transactionAuditor = new TransactionAuditor()
 }
 
 trait LookupServiceBinder {
@@ -58,6 +59,8 @@ trait LookupService extends LookupServiceBinder {
   protected val nrsConnector: BirthConnector
   protected val groniConnector: BirthConnector
   protected val matchingService: MatchingService
+
+  protected val transactionAuditor : TransactionAuditor
 
   val CLASS_NAME: String = this.getClass.getCanonicalName
 
@@ -120,8 +123,6 @@ trait LookupService extends LookupServiceBinder {
       * - payload details
       */
 
-      // TODO pass this in as a dependency and mock in tests
-    val transactionAuditor : TransactionAuditor = new TransactionAuditor()
     val matchAudit = downstreamAPIAuditor.recordFoundAndMatchToMap(records, matchResult)
     val transactionAudit = transactionAuditor.transactionToMap(payload, records, matchResult)
 

--- a/app/uk/gov/hmrc/brm/services/LookupService.scala
+++ b/app/uk/gov/hmrc/brm/services/LookupService.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.brm.metrics._
 import uk.gov.hmrc.brm.models.brm.Payload
 import uk.gov.hmrc.brm.models.matching.ResultMatch
 import uk.gov.hmrc.brm.models.response.Record
-import uk.gov.hmrc.brm.utils.BrmLogger._
+import uk.gov.hmrc.brm.utils.BRMLogger._
 import uk.gov.hmrc.brm.utils.{BirthRegisterCountry, BirthResponseBuilder, RecordParser}
 import uk.gov.hmrc.play.http._
 
@@ -120,6 +120,7 @@ trait LookupService extends LookupServiceBinder {
       * - payload details
       */
 
+      // TODO pass this in as a dependency and mock in tests
     val transactionAuditor : TransactionAuditor = new TransactionAuditor()
     val matchAudit = downstreamAPIAuditor.recordFoundAndMatchToMap(records, matchResult)
     val transactionAudit = transactionAuditor.transactionToMap(payload, records, matchResult)

--- a/app/uk/gov/hmrc/brm/services/MatchingAlgorithm.scala
+++ b/app/uk/gov/hmrc/brm/services/MatchingAlgorithm.scala
@@ -107,7 +107,6 @@ trait MatchingAlgorithm {
 
 object FullMatching extends MatchingAlgorithm {
 
-  // TODO also call names() on lastName to strip out the spaces from the record
   override def matchFunction: PartialFunction[(Payload, Record), ResultMatch] = {
     case (payload, record) =>
       val firstNames = matchFirstNames(payload, record)

--- a/app/uk/gov/hmrc/brm/services/MatchingService.scala
+++ b/app/uk/gov/hmrc/brm/services/MatchingService.scala
@@ -21,14 +21,20 @@ import uk.gov.hmrc.brm.config.BrmConfig
 import uk.gov.hmrc.brm.models.brm.Payload
 import uk.gov.hmrc.brm.models.matching.ResultMatch
 import uk.gov.hmrc.brm.models.response.Record
-import uk.gov.hmrc.brm.utils.BrmLogger._
+import uk.gov.hmrc.brm.utils.BRMLogger._
 import uk.gov.hmrc.brm.utils.MatchingType
 import uk.gov.hmrc.play.http.HeaderCarrier
+
+object MatchingService extends MatchingService {
+  override val matchOnMultiple: Boolean = BrmConfig.matchOnMultiple
+  override val auditor = new MatchingAudit()
+}
 
 trait MatchingService {
   val CLASS_NAME: String = this.getClass.getCanonicalName
 
   protected val matchOnMultiple: Boolean
+  protected val auditor : MatchingAudit
 
   def performMatch(input: Payload,
                    records: List[Record],
@@ -49,7 +55,7 @@ trait MatchingService {
     info(CLASS_NAME, "performMatch", s"hasMultipleRecords -> ${records.length > 1}")
 
     // audit match result
-    new MatchingAudit().audit(result.audit, Some(input))
+    auditor.audit(result.audit, Some(input))
 
     result
   }
@@ -60,8 +66,4 @@ trait MatchingService {
     if (fullMatch) MatchingType.FULL else MatchingType.PARTIAL
   }
 
-}
-
-object MatchingService extends MatchingService {
-  override val matchOnMultiple: Boolean = BrmConfig.matchOnMultiple
 }

--- a/app/uk/gov/hmrc/brm/services/parser/NameParser.scala
+++ b/app/uk/gov/hmrc/brm/services/parser/NameParser.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.brm.services.parser
 
 import uk.gov.hmrc.brm.config.BrmConfig
-import uk.gov.hmrc.brm.utils.BrmLogger
+import uk.gov.hmrc.brm.utils.BRMLogger
 
 /**
   * Created by adamconder on 02/02/2017.
@@ -30,7 +30,7 @@ object NameParser {
 
     def names: List[String] = {
       val nameArray: Array[String] = s.toLowerCase.trim.split(regex)
-      BrmLogger.debug("NameParser", "parse", s"names: ${nameArray.toList}, regex: $regex")
+      BRMLogger.debug("NameParser", "parse", s"names: ${nameArray.toList}, regex: $regex")
 
       nameArray.toList
     }
@@ -40,15 +40,15 @@ object NameParser {
   implicit class FilterList[T](left : List[T]) {
 
     def filter(right : List[T]) : List[T] = {
-      BrmLogger.debug("NameParser", "filter", s"left: $left right: $right")
+      BRMLogger.debug("NameParser", "filter", s"left: $left right: $right")
 
       if (left.length > right.length || left.isEmpty || right.isEmpty) {
         right
       } else {
         val difference = right.length - left.length
-        BrmLogger.debug("NameParser", "parser", s"dropping: $difference")
+        BRMLogger.debug("NameParser", "parser", s"dropping: $difference")
         val dropped = right.dropRight(difference)
-        BrmLogger.debug("NameParser", "parser", s"dropped: $dropped")
+        BRMLogger.debug("NameParser", "parser", s"dropped: $dropped")
         dropped
       }
     }

--- a/app/uk/gov/hmrc/brm/utils/BirthRegisterCountry.scala
+++ b/app/uk/gov/hmrc/brm/utils/BirthRegisterCountry.scala
@@ -54,7 +54,6 @@ object BirthRegisterCountry extends Enumeration {
   }
 
   def birthRegisterWrites = new Writes[BirthRegisterCountry] {
-
     def writes(d: BirthRegisterCountry): JsValue = JsString(d.toString)
   }
 

--- a/app/uk/gov/hmrc/brm/utils/BrmException.scala
+++ b/app/uk/gov/hmrc/brm/utils/BrmException.scala
@@ -18,11 +18,9 @@ package uk.gov.hmrc.brm.utils
 
 import play.api.libs.json.Json
 import play.api.mvc.{Controller, Result}
-import uk.gov.hmrc.brm.audit.{BRMAudit, MatchingAudit, TransactionAuditor}
+import uk.gov.hmrc.brm.audit.BRMAudit
 import uk.gov.hmrc.brm.implicits.Implicits._
 import uk.gov.hmrc.brm.models.brm.Payload
-import uk.gov.hmrc.brm.models.matching.ResultMatch
-import uk.gov.hmrc.brm.services.Bad
 import uk.gov.hmrc.brm.utils.BrmLogger._
 import uk.gov.hmrc.play.http._
 
@@ -30,18 +28,6 @@ trait BrmException extends Controller {
 
   val CLASS_NAME: String = "BrmException"
   val METHOD_NAME: String = "handleException"
-
-  private def auditTransaction()(implicit payload: Payload,
-                              auditor: BRMAudit,
-                              hc: HeaderCarrier): Unit = {
-
-    val matchResult = ResultMatch(Bad(), Bad(), Bad(), Bad())
-    new MatchingAudit().audit(matchResult.audit, Some(payload))
-
-    auditor.audit(auditor.recordFoundAndMatchToMap(Nil, matchResult), Some(payload))
-
-    new TransactionAuditor().transactionToMap(payload, Nil, matchResult)
-  }
 
   private def logException(message: Option[String] = None, status: Option[String] = None, statusCode: Int)(implicit payload: Payload) = {
     MetricsFactory.getMetrics().status(statusCode)
@@ -94,11 +80,8 @@ trait BrmException extends Controller {
       Ok(Json.toJson(BirthResponseBuilder.withNoMatch()))
   }
 
-  def notFoundExceptionPF(message: String)(implicit payload: Payload,
-                                           auditor: BRMAudit,
-                                           hc: HeaderCarrier) : PartialFunction[Throwable, Result] = {
+  def notFoundExceptionPF(message: String)(implicit payload: Payload) : PartialFunction[Throwable, Result] = {
     case e: NotFoundException =>
-      auditTransaction()
       logException(Some(message), Some(s"NotFound: ${e.getMessage}"), NOT_FOUND)
       Ok(Json.toJson(BirthResponseBuilder.withNoMatch()))
   }

--- a/app/uk/gov/hmrc/brm/utils/BrmException.scala
+++ b/app/uk/gov/hmrc/brm/utils/BrmException.scala
@@ -18,11 +18,13 @@ package uk.gov.hmrc.brm.utils
 
 import play.api.libs.json.Json
 import play.api.mvc.{Controller, Result}
-import uk.gov.hmrc.brm.audit.BRMAudit
 import uk.gov.hmrc.brm.implicits.Implicits._
 import uk.gov.hmrc.brm.models.brm.Payload
 import uk.gov.hmrc.brm.utils.BRMLogger._
 import uk.gov.hmrc.play.http._
+
+
+// TODO Add case _ to catch exceptions?
 
 trait BrmException extends Controller {
 

--- a/app/uk/gov/hmrc/brm/utils/BrmException.scala
+++ b/app/uk/gov/hmrc/brm/utils/BrmException.scala
@@ -21,7 +21,7 @@ import play.api.mvc.{Controller, Result}
 import uk.gov.hmrc.brm.audit.BRMAudit
 import uk.gov.hmrc.brm.implicits.Implicits._
 import uk.gov.hmrc.brm.models.brm.Payload
-import uk.gov.hmrc.brm.utils.BrmLogger._
+import uk.gov.hmrc.brm.utils.BRMLogger._
 import uk.gov.hmrc.play.http._
 
 trait BrmException extends Controller {

--- a/app/uk/gov/hmrc/brm/utils/BrmLogger.scala
+++ b/app/uk/gov/hmrc/brm/utils/BrmLogger.scala
@@ -20,22 +20,22 @@ import play.api.Logger
 
 class BRMLogger(logger: org.slf4j.Logger) extends Logger(logger) {
 
-  val BRM_KEY: String = s"BRM-Key:${KeyGenerator.getKey()}"
+  val BRM_KEY: String = s"BRM-Key"
 
   def info(className: String, methodName: String, message: String): Unit = {
-    logger.info(s"[$BRM_KEY], [$className][$methodName] : [$message]")
+    logger.info(s"[$BRM_KEY:${KeyGenerator.getKey()}], [$className][$methodName] : [$message]")
   }
 
   def warn(className: String, methodName: String, message: String): Unit = {
-    logger.warn(s"[$BRM_KEY],[$className][$methodName] : [$message]")
+    logger.warn(s"[$BRM_KEY:${KeyGenerator.getKey()}],[$className][$methodName] : [$message]")
   }
 
   def error(className: String, methodName: String, message: String): Unit = {
-    logger.error(s"[$BRM_KEY],[$className][$methodName] : [$message]")
+    logger.error(s"[$BRM_KEY:${KeyGenerator.getKey()}],[$className][$methodName] : [$message]")
   }
 
   def debug(className: String, methodName: String, message: String): Unit = {
-    logger.debug(s"[$BRM_KEY],[$className][$methodName] : [$message]")
+    logger.debug(s"[$BRM_KEY:${KeyGenerator.getKey()}],[$className][$methodName] : [$message]")
   }
 
   def info(objectName: Object, methodName: String, message: String): Unit = {

--- a/app/uk/gov/hmrc/brm/utils/BrmLogger.scala
+++ b/app/uk/gov/hmrc/brm/utils/BrmLogger.scala
@@ -18,24 +18,24 @@ package uk.gov.hmrc.brm.utils
 
 import play.api.Logger
 
-class BrmLogger(logger: org.slf4j.Logger) extends Logger(logger) {
+class BRMLogger(logger: org.slf4j.Logger) extends Logger(logger) {
 
-  val BRM_KEY: String = "BRM-Key"
+  val BRM_KEY: String = s"BRM-Key:${KeyGenerator.getKey()}"
 
   def info(className: String, methodName: String, message: String): Unit = {
-    logger.info(s"[$BRM_KEY:${Keygenerator.geKey()}], [$className][$methodName] : [$message]")
+    logger.info(s"[$BRM_KEY], [$className][$methodName] : [$message]")
   }
 
   def warn(className: String, methodName: String, message: String): Unit = {
-    logger.warn(s"[$BRM_KEY:${Keygenerator.geKey()}],[$className][$methodName] : [$message]")
+    logger.warn(s"[$BRM_KEY],[$className][$methodName] : [$message]")
   }
 
   def error(className: String, methodName: String, message: String): Unit = {
-    logger.error(s"[$BRM_KEY:${Keygenerator.geKey()}],[$className][$methodName] : [$message]")
+    logger.error(s"[$BRM_KEY],[$className][$methodName] : [$message]")
   }
 
   def debug(className: String, methodName: String, message: String): Unit = {
-    logger.debug(s"[$BRM_KEY:${Keygenerator.geKey()}],[$className][$methodName] : [$message]")
+    logger.debug(s"[$BRM_KEY],[$className][$methodName] : [$message]")
   }
 
   def info(objectName: Object, methodName: String, message: String): Unit = {
@@ -55,4 +55,4 @@ class BrmLogger(logger: org.slf4j.Logger) extends Logger(logger) {
   }
 }
 
-object BrmLogger extends BrmLogger(Logger.logger)
+object BRMLogger extends BRMLogger(Logger.logger)

--- a/app/uk/gov/hmrc/brm/utils/CommonUtil.scala
+++ b/app/uk/gov/hmrc/brm/utils/CommonUtil.scala
@@ -35,7 +35,7 @@ object CommonUtil extends Controller {
     regEx,
     groupNames: _*) findFirstMatchIn _
 
-  def getApiVersion(request: Request[JsValue]): String = {
+  def getApiVersion[A](request: Request[A]): String = {
     val accept = request.headers.get(HeaderNames.ACCEPT)
     accept.flatMap(
       a =>

--- a/app/uk/gov/hmrc/brm/utils/HeaderValidator.scala
+++ b/app/uk/gov/hmrc/brm/utils/HeaderValidator.scala
@@ -72,10 +72,7 @@ trait HeaderValidator extends Results {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
 
       if (rules(request.headers.get(HeaderNames.ACCEPT), request.headers.get("Audit-Source"))) {
-
-        // generate unique key
         KeyGenerator.generateAndSetKey(request)
-
         block(request)
       } else {
         val errorCode = 145

--- a/app/uk/gov/hmrc/brm/utils/HeaderValidator.scala
+++ b/app/uk/gov/hmrc/brm/utils/HeaderValidator.scala
@@ -72,6 +72,9 @@ trait HeaderValidator extends Results {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
 
       if (rules(request.headers.get(HeaderNames.ACCEPT), request.headers.get("Audit-Source"))) {
+        // generate unique key
+        KeyGenerator.generateAndSetKey(request)
+
         block(request)
       } else {
         val errorCode = 145

--- a/app/uk/gov/hmrc/brm/utils/HeaderValidator.scala
+++ b/app/uk/gov/hmrc/brm/utils/HeaderValidator.scala
@@ -72,6 +72,7 @@ trait HeaderValidator extends Results {
     def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
 
       if (rules(request.headers.get(HeaderNames.ACCEPT), request.headers.get("Audit-Source"))) {
+
         // generate unique key
         KeyGenerator.generateAndSetKey(request)
 

--- a/app/uk/gov/hmrc/brm/utils/Keygenerator.scala
+++ b/app/uk/gov/hmrc/brm/utils/Keygenerator.scala
@@ -18,16 +18,15 @@ package uk.gov.hmrc.brm.utils
 
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
-import play.api.libs.json.JsValue
 import play.api.mvc.Request
 import uk.gov.hmrc.brm.utils.CommonUtil._
 
-object Keygenerator {
+object KeyGenerator {
 
   val DATE_FORMAT: String = "yyyyMMdd:HHmmssSS"
   private var keyForRequest: String = null
 
-  def generateKey(request: Request[JsValue]) = {
+  def generateKey[A](request: Request[A]) = {
     val formattedDate: String = getDateKey
     val apiVersion: String = getApiVersion(request)
     //format is date-requestid-audit source - api version number
@@ -42,7 +41,7 @@ object Keygenerator {
     formattedDate
   }
 
-  def geKey(): String = {
+  def getKey(): String = {
     keyForRequest
   }
 
@@ -50,11 +49,9 @@ object Keygenerator {
     keyForRequest = key
   }
 
-  def generateAndSetKey(request: Request[JsValue]): Unit = {
+  def generateAndSetKey[A](request: Request[A]): Unit = {
     val key = generateKey(request)
     setKey(key)
   }
-
-
 
 }

--- a/app/uk/gov/hmrc/brm/utils/RecordParser.scala
+++ b/app/uk/gov/hmrc/brm/utils/RecordParser.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.play.http.HeaderCarrier
 // TODO Make generic, accept type C, S to model
 sealed trait ResponseParser {
 
-  import uk.gov.hmrc.brm.utils.BrmLogger._
+  import uk.gov.hmrc.brm.utils.BRMLogger._
 
   def parse(json: JsValue)(implicit hc : HeaderCarrier, manifest: reflect.Manifest[Record]) : List[Record] = {
     val name = manifest.toString()

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -34,29 +34,43 @@
         </encoder>
     </appender>
 
-    <logger name="accesslog" level="INFO" additivity="false">
-        <appender-ref ref="ACCESS_LOG_FILE" />
-    </logger>
-
-    <logger name="com.ning.http.client" level="WARN"/>
-    <logger name="org.asynchttpclient.netty.channel.DefaultChannelPool" level="WARN"/>
-    <logger name="org.asynchttpclient.netty" level="WARN"/>
-
-    <logger name="uk.gov" level="INFO"/>
-
-    <logger name="com.google.inject" level="INFO"/>
-
-    <logger name="akka.event" level="INFO"/>
-
-    <logger name="io.netty" level="OFF"/>
-
-    <logger name="application" level="DEBUG"/>
-
-    <logger name="connector" level="INFO">
+    <logger name="com.ning.http.client" level="WARN">
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="INFO">
+    <logger name="java.nio.channels" level="OFF">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="org.asynchttpclient.netty.channel" level="OFF">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="uk.gov" level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="com.google.inject" level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka.event" level="OFF">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="io.netty" level="OFF">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="application">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="connector">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <root level="DEBUG">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="ACCESS_LOG_FILE"/>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -42,7 +42,7 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <logger name="org.asynchttpclient.netty.channel" level="OFF">
+    <logger name="org.asynchttpclient.netty" level="WARN">
         <appender-ref ref="STDOUT"/>
     </logger>
 

--- a/test/uk/gov/hmrc/brm/audit/EnglandAndWalesAuditSpec.scala
+++ b/test/uk/gov/hmrc/brm/audit/EnglandAndWalesAuditSpec.scala
@@ -18,14 +18,15 @@ package uk.gov.hmrc.brm.audit
 
 import org.joda.time.LocalDate
 import org.mockito.Matchers
+import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import uk.gov.hmrc.brm.BRMFakeApplication
 import uk.gov.hmrc.brm.models.brm.Payload
 import uk.gov.hmrc.brm.utils.BirthRegisterCountry
+import uk.gov.hmrc.brm.utils.Mocks._
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
-import uk.gov.hmrc.play.test.UnitSpec
-import org.mockito.Mockito._
 import uk.gov.hmrc.play.http.HeaderCarrier
+import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.Future
 
@@ -35,7 +36,7 @@ import scala.concurrent.Future
 class EnglandAndWalesAuditSpec extends UnitSpec with MockitoSugar with BRMFakeApplication {
 
   val connector = mock[AuditConnector]
-  val auditor = new EnglandAndWalesAudit(connector)
+  val auditor = auditorFixtures.englandAndWalesAudit
 
   implicit val hc = HeaderCarrier()
 

--- a/test/uk/gov/hmrc/brm/audit/MatchingAuditSpec.scala
+++ b/test/uk/gov/hmrc/brm/audit/MatchingAuditSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.mock.MockitoSugar
 import uk.gov.hmrc.brm.BRMFakeApplication
 import uk.gov.hmrc.brm.models.brm.Payload
 import uk.gov.hmrc.brm.utils.BirthRegisterCountry
+import uk.gov.hmrc.brm.utils.Mocks._
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
@@ -35,7 +36,7 @@ import scala.concurrent.Future
 class MatchingAuditSpec extends UnitSpec with MockitoSugar with BRMFakeApplication {
 
   val connector = mock[AuditConnector]
-  val auditor = new MatchingAudit(connector)
+  val auditor = auditorFixtures.matchingAudit
 
   implicit val hc = HeaderCarrier()
 

--- a/test/uk/gov/hmrc/brm/audit/NorthernIrelandSpec.scala
+++ b/test/uk/gov/hmrc/brm/audit/NorthernIrelandSpec.scala
@@ -34,8 +34,10 @@ import scala.concurrent.Future
   */
 class NorthernIrelandSpec extends UnitSpec with MockitoSugar with BRMFakeApplication {
 
+  import uk.gov.hmrc.brm.utils.Mocks._
+
   val connector = mock[AuditConnector]
-  val auditor = new NorthernIrelandAudit(connector)
+  val auditor = auditorFixtures.northernIrelandAudit
 
   implicit val hc = HeaderCarrier()
 
@@ -53,6 +55,9 @@ class NorthernIrelandSpec extends UnitSpec with MockitoSugar with BRMFakeApplica
     "audit requests when using child's details" in {
       val payload = Payload(None, "Adam", "Test", LocalDate.now(), BirthRegisterCountry.ENGLAND)
       val event = Map("match" -> "true")
+
+      when(connector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
       val result = await(auditor.audit(event, Some(payload)))
       result shouldBe AuditResult.Success
     }

--- a/test/uk/gov/hmrc/brm/audit/RequestsAndResultsAuditSpec.scala
+++ b/test/uk/gov/hmrc/brm/audit/RequestsAndResultsAuditSpec.scala
@@ -23,8 +23,10 @@ import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
 import org.specs2.mock.mockito.ArgumentCapture
 import uk.gov.hmrc.brm.models.brm.Payload
+import uk.gov.hmrc.brm.models.matching.ResultMatch
 import uk.gov.hmrc.brm.models.response.Record
 import uk.gov.hmrc.brm.models.response.gro.Child
+import uk.gov.hmrc.brm.services.Bad
 import uk.gov.hmrc.brm.utils.BirthRegisterCountry
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 import uk.gov.hmrc.play.http.HeaderCarrier
@@ -38,7 +40,7 @@ import scala.concurrent.Future
 class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneAppPerSuite {
 
   val connector = mock[AuditConnector]
-  val auditor = new RequestsAndResultsAudit(connector)
+  val auditor = new TransactionAuditor(connector)
   implicit val hc = HeaderCarrier()
 
   "RequestsAndResultsAudit" should {
@@ -47,7 +49,7 @@ class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneApp
       val localDate = new LocalDate("2017-02-17")
       val payload = Payload(Some("123456789"), "Adam", "Test", localDate, BirthRegisterCountry.ENGLAND)
       val argumentCapture = new ArgumentCapture[AuditEvent]
-      val event = Map("match" -> "true")
+      val event = auditor.transactionToMap(payload, Nil, ResultMatch(Bad(), Bad(), Bad(), Bad()))
 
       when(connector.sendEvent(argumentCapture.capture)(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
       val result = await(auditor.audit(event, Some(payload)))
@@ -64,7 +66,7 @@ class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneApp
       val localDate = new LocalDate("2017-02-17")
       val payload = Payload(None, "Adam", "Test", localDate, BirthRegisterCountry.ENGLAND)
       val argumentCapture = new ArgumentCapture[AuditEvent]
-      val event = Map("match" -> "true")
+      val event = auditor.transactionToMap(payload, Nil, ResultMatch(Bad(), Bad(), Bad(), Bad()))
 
       when(connector.sendEvent(argumentCapture.capture)(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
       val result = await(auditor.audit(event, Some(payload)))

--- a/test/uk/gov/hmrc/brm/audit/RequestsAndResultsAuditSpec.scala
+++ b/test/uk/gov/hmrc/brm/audit/RequestsAndResultsAuditSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.brm.models.response.Record
 import uk.gov.hmrc.brm.models.response.gro.Child
 import uk.gov.hmrc.brm.services.Bad
 import uk.gov.hmrc.brm.utils.BirthRegisterCountry
-import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
 
@@ -39,8 +39,8 @@ import scala.concurrent.Future
   */
 class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneAppPerSuite {
 
-  val connector = mock[AuditConnector]
-  val auditor = new TransactionAuditor(connector)
+  import uk.gov.hmrc.brm.utils.Mocks._
+
   implicit val hc = HeaderCarrier()
 
   "RequestsAndResultsAudit" should {
@@ -49,10 +49,10 @@ class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneApp
       val localDate = new LocalDate("2017-02-17")
       val payload = Payload(Some("123456789"), "Adam", "Test", localDate, BirthRegisterCountry.ENGLAND)
       val argumentCapture = new ArgumentCapture[AuditEvent]
-      val event = auditor.transactionToMap(payload, Nil, ResultMatch(Bad(), Bad(), Bad(), Bad()))
+      val event = auditorFixtures.transactionAudit.transactionToMap(payload, Nil, ResultMatch(Bad(), Bad(), Bad(), Bad()))
 
-      when(connector.sendEvent(argumentCapture.capture)(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
-      val result = await(auditor.audit(event, Some(payload)))
+      when(mockAuditConnector.sendEvent(argumentCapture.capture)(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+      val result = await(auditorFixtures.transactionAudit.audit(event, Some(payload)))
       result shouldBe AuditResult.Success
 
       argumentCapture.value.detail("payload.birthReferenceNumber").contains("123456789")
@@ -66,10 +66,10 @@ class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneApp
       val localDate = new LocalDate("2017-02-17")
       val payload = Payload(None, "Adam", "Test", localDate, BirthRegisterCountry.ENGLAND)
       val argumentCapture = new ArgumentCapture[AuditEvent]
-      val event = auditor.transactionToMap(payload, Nil, ResultMatch(Bad(), Bad(), Bad(), Bad()))
+      val event = auditorFixtures.transactionAudit.transactionToMap(payload, Nil, ResultMatch(Bad(), Bad(), Bad(), Bad()))
 
-      when(connector.sendEvent(argumentCapture.capture)(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
-      val result = await(auditor.audit(event, Some(payload)))
+      when(mockAuditConnector.sendEvent(argumentCapture.capture)(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+      val result = await(auditorFixtures.transactionAudit.audit(event, Some(payload)))
       result shouldBe AuditResult.Success
 
       argumentCapture.value.detail("payload.birthReferenceNumber") shouldBe "No Birth Reference Number"
@@ -82,7 +82,7 @@ class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneApp
     "throw Illegal argument exception when no payload is provided" in {
       val event = Map("match" -> "true")
       intercept[IllegalArgumentException] {
-        await(auditor.audit(event, None))
+        await(auditorFixtures.transactionAudit.audit(event, None))
       }
     }
 
@@ -91,7 +91,7 @@ class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneApp
   "responseWordCount" should {
 
     "return empty Map when an empty list is sent" in {
-      val response = auditor.responseWordCount(List())
+      val response = auditorFixtures.transactionAudit.responseWordCount(List())
       response shouldBe a[Map[_,_]]
       response.isEmpty shouldBe true
     }
@@ -103,7 +103,7 @@ class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneApp
         "",
         Some(new LocalDate("2009-06-30"))))
 
-      val response = auditor.responseWordCount(List(child))
+      val response = auditorFixtures.transactionAudit.responseWordCount(List(child))
 
       response shouldBe a[Map[_, _]]
       response("records.record1.numberOfForenames") shouldBe "0"
@@ -117,7 +117,7 @@ class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneApp
         "SMITH",
         Some(new LocalDate("2009-06-30"))))
 
-      val response = auditor.responseWordCount(List(child))
+      val response = auditorFixtures.transactionAudit.responseWordCount(List(child))
 
       response("records.record1.numberOfForenames") shouldBe "2"
       response("records.record1.numberOfLastnames") shouldBe "1"
@@ -136,7 +136,7 @@ class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneApp
         "SMITH",
         Some(new LocalDate("2009-06-30"))))
 
-      val response = auditor.responseWordCount(List(child, child2))
+      val response = auditorFixtures.transactionAudit.responseWordCount(List(child, child2))
 
       response("records.record1.numberOfForenames") shouldBe "2"
       response("records.record1.numberOfLastnames") shouldBe "1"
@@ -148,7 +148,7 @@ class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneApp
   "responseCharacterCount" should {
 
     "return empty Map when an empty list is sent" in {
-      val response = auditor.responseCharacterCount(List())
+      val response = auditorFixtures.transactionAudit.responseCharacterCount(List())
       response shouldBe a[Map[_,_]]
       response.isEmpty shouldBe true
     }
@@ -160,7 +160,7 @@ class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneApp
         "SMITH",
         Some(new LocalDate("2009-06-30"))))
 
-      val response = auditor.responseCharacterCount(List(child))
+      val response = auditorFixtures.transactionAudit.responseCharacterCount(List(child))
       response shouldBe a[Map[_, _]]
       response("records.record1.numberOfCharactersInFirstName") shouldBe "9"
       response("records.record1.numberOfCharactersInLastName") shouldBe "5"
@@ -178,7 +178,7 @@ class RequestsAndResultsAuditSpec extends UnitSpec with MockitoSugar with OneApp
         "Andrews",
         Some(new LocalDate("2009-08-30"))))
 
-      val response = auditor.responseCharacterCount(List(child1, child2))
+      val response = auditorFixtures.transactionAudit.responseCharacterCount(List(child1, child2))
 
       response("records.record1.numberOfCharactersInFirstName") shouldBe "9"
       response("records.record1.numberOfCharactersInLastName") shouldBe "5"

--- a/test/uk/gov/hmrc/brm/audit/ScotlandAuditSpec.scala
+++ b/test/uk/gov/hmrc/brm/audit/ScotlandAuditSpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.mock.MockitoSugar
 import uk.gov.hmrc.brm.BRMFakeApplication
 import uk.gov.hmrc.brm.models.brm.Payload
 import uk.gov.hmrc.brm.utils.BirthRegisterCountry
-import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
 
@@ -34,8 +34,9 @@ import scala.concurrent.Future
   */
 class ScotlandAuditSpec extends UnitSpec with MockitoSugar with BRMFakeApplication {
 
-  val connector = mock[AuditConnector]
-  val auditor = new ScotlandAudit(connector)
+  import uk.gov.hmrc.brm.utils.Mocks._
+
+  val auditor = auditorFixtures.scotlandAudit
 
   implicit val hc = HeaderCarrier()
 
@@ -45,7 +46,7 @@ class ScotlandAuditSpec extends UnitSpec with MockitoSugar with BRMFakeApplicati
       val payload = Payload(Some("123456789"), "Adam", "Test", LocalDate.now(), BirthRegisterCountry.ENGLAND)
       val event = Map("match" -> "true")
 
-      when(connector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+      when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
       val result = await(auditor.audit(event, Some(payload)))
       result shouldBe AuditResult.Success
     }
@@ -53,6 +54,8 @@ class ScotlandAuditSpec extends UnitSpec with MockitoSugar with BRMFakeApplicati
     "audit requests when using child's details" in {
       val payload = Payload(None, "Adam", "Test", LocalDate.now(), BirthRegisterCountry.ENGLAND)
       val event = Map("match" -> "true")
+
+      when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
       val result = await(auditor.audit(event, Some(payload)))
       result shouldBe AuditResult.Success
     }

--- a/test/uk/gov/hmrc/brm/audit/WhereBirthRegisteredAuditSpec.scala
+++ b/test/uk/gov/hmrc/brm/audit/WhereBirthRegisteredAuditSpec.scala
@@ -22,7 +22,7 @@ import org.mockito.Matchers
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import uk.gov.hmrc.brm.BRMFakeApplication
-import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
 
@@ -34,21 +34,21 @@ import scala.concurrent.duration.Duration
   */
 class WhereBirthRegisteredAuditSpec extends UnitSpec with MockitoSugar with BRMFakeApplication {
 
-  val connector = mock[AuditConnector]
-  val auditor = new WhereBirthRegisteredAudit(connector)
-  implicit val hc = HeaderCarrier()
+  import uk.gov.hmrc.brm.utils.Mocks._
 
+  val auditor = auditorFixtures.whereBirthRegisteredAudit
+  implicit val hc = HeaderCarrier()
 
   "WhereBirthRegisteredAudit" should {
 
     "audit country when an invalid birth country is used" in {
-      when(connector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+      when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
       val result = await(auditor.audit(Map(), None))
       result shouldBe AuditResult.Success
     }
 
     "not audit when datastream is down" in {
-      when(connector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.failed(AuditResult.Failure("")))
+      when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.failed(AuditResult.Failure("")))
       val result = await(auditor.audit(Map(), None))(Duration.apply(20, TimeUnit.SECONDS))
       result shouldBe a[AuditResult.Failure]
     }

--- a/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerDOBSwitchSpec.scala
+++ b/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerDOBSwitchSpec.scala
@@ -25,11 +25,10 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsValue
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.brm.connectors._
-import uk.gov.hmrc.brm.services.{LookupService, MatchingService}
 import uk.gov.hmrc.brm.utils.JsonUtils
+import uk.gov.hmrc.brm.utils.Mocks._
 import uk.gov.hmrc.brm.utils.TestHelper._
-import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import uk.gov.hmrc.play.http.HttpResponse
 import uk.gov.hmrc.play.test.UnitSpec
 
@@ -46,23 +45,9 @@ class BirthEventsControllerDOBSwitchSpec extends UnitSpec with OneAppPerTest wit
     .withHeaders((ACCEPT, "application/vnd.hmrc.1.0+json"), ("Audit-Source", "DFS"))
     .withBody(v)
 
-  def httpResponse(js: JsValue) = HttpResponse.apply(200, Some(js))
+  def httpResponse(js: JsValue) = HttpResponse.apply(OK, Some(js))
 
   def httpResponse(responseCode: Int) = HttpResponse.apply(responseCode)
-
-  val mockConnector = mock[BirthConnector]
-  val mockAuditConnector = mock[AuditConnector]
-
-  object MockLookupService extends LookupService {
-    override val groConnector = mockConnector
-    override val groniConnector = new GRONIConnector
-    override val nrsConnector = new NRSConnector
-    override val matchingService = MatchingService
-  }
-
-  object MockController extends BirthEventsController {
-    override val service = MockLookupService
-  }
 
   val config: Map[String, _] = Map(
     "microservice.services.birth-registration-matching.validateDobForGro" -> true,
@@ -80,6 +65,7 @@ class BirthEventsControllerDOBSwitchSpec extends UnitSpec with OneAppPerTest wit
     "return matched value of true when the dateOfBirth is greater than 2009-07-01 and the gro record matches" in {
       when(MockController.service.groConnector.getReference(Matchers.any())(Matchers.any())).thenReturn(Future.successful(httpResponse(groJsonResponseObject20120216)))
       when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
       val request = postRequest(userValidDOB)
       val result = await(MockController.post().apply(request))
       status(result) shouldBe OK
@@ -90,6 +76,7 @@ class BirthEventsControllerDOBSwitchSpec extends UnitSpec with OneAppPerTest wit
     "return matched value of true when the dateOfBirth is equal to 2009-07-01 and the gro record matches" in {
       when(MockController.service.groConnector.getReference(Matchers.any())(Matchers.any())).thenReturn(Future.successful(httpResponse(groJsonResponseObject20090701)))
       when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
       val request = postRequest(userValidDOB20090701)
       val result = await(MockController.post().apply(request))
       status(result) shouldBe OK
@@ -100,6 +87,7 @@ class BirthEventsControllerDOBSwitchSpec extends UnitSpec with OneAppPerTest wit
     "return matched value of false when the dateOfBirth is invalid and the gro record matches" in {
       when(MockController.service.groConnector.getReference(Matchers.any())(Matchers.any())).thenReturn(Future.successful(httpResponse(groJsonResponseObject)))
       when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
       val request = postRequest(userInvalidDOB)
       val result = await(MockController.post().apply(request))
       status(result) shouldBe OK
@@ -110,6 +98,7 @@ class BirthEventsControllerDOBSwitchSpec extends UnitSpec with OneAppPerTest wit
     "return matched value of false when the dateOfBirth is one day earlier than 2009-07-01 and the gro record matches" in {
       when(MockController.service.groConnector.getReference(Matchers.any())(Matchers.any())).thenReturn(Future.successful(httpResponse(groJsonResponseObject20090630)))
       when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
       val request = postRequest(userValidDOB20090630)
       val result = await(MockController.post().apply(request))
       status(result) shouldBe OK

--- a/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerDOBSwitchSpec.scala
+++ b/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerDOBSwitchSpec.scala
@@ -25,7 +25,6 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsValue
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.brm.audit.RequestsAndResultsAudit
 import uk.gov.hmrc.brm.connectors._
 import uk.gov.hmrc.brm.services.{LookupService, MatchingService}
 import uk.gov.hmrc.brm.utils.JsonUtils
@@ -48,6 +47,7 @@ class BirthEventsControllerDOBSwitchSpec extends UnitSpec with OneAppPerTest wit
     .withBody(v)
 
   def httpResponse(js: JsValue) = HttpResponse.apply(200, Some(js))
+
   def httpResponse(responseCode: Int) = HttpResponse.apply(responseCode)
 
   val mockConnector = mock[BirthConnector]
@@ -58,7 +58,6 @@ class BirthEventsControllerDOBSwitchSpec extends UnitSpec with OneAppPerTest wit
     override val groniConnector = new GRONIConnector
     override val nrsConnector = new NRSConnector
     override val matchingService = MatchingService
-    override val requestAndResponseAuditor = new RequestsAndResultsAudit(mockAuditConnector)
   }
 
   object MockController extends BirthEventsController {

--- a/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerDetailsSearchSwitchSpec.scala
+++ b/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerDetailsSearchSwitchSpec.scala
@@ -26,9 +26,11 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsValue
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import uk.gov.hmrc.brm.audit.TransactionAuditor
 import uk.gov.hmrc.brm.models.matching.BirthMatchResponse
 import uk.gov.hmrc.brm.services.LookupService
 import uk.gov.hmrc.brm.utils.TestHelper._
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.Future

--- a/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerValidationLengthSpec.scala
+++ b/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerValidationLengthSpec.scala
@@ -25,12 +25,10 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsValue
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.brm.audit.RequestsAndResultsAudit
 import uk.gov.hmrc.brm.connectors._
 import uk.gov.hmrc.brm.services.{LookupService, MatchingService}
 import uk.gov.hmrc.brm.utils.JsonUtils
 import uk.gov.hmrc.brm.utils.TestHelper._
-import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 import uk.gov.hmrc.play.http.HttpResponse
 import uk.gov.hmrc.play.test.UnitSpec
 
@@ -40,23 +38,21 @@ class BirthEventsControllerValidationLengthSpec extends UnitSpec with OneAppPerT
 
   val groJsonResponseObject = JsonUtils.getJsonFromFile("500035710")
 
-
   def postRequest(v: JsValue): FakeRequest[JsValue] = FakeRequest("POST", "/api/v0/events/birth")
     .withHeaders((ACCEPT, "application/vnd.hmrc.1.0+json"), ("Audit-Source", "DFS"))
     .withBody(v)
 
   def httpResponse(js: JsValue) = HttpResponse.apply(200, Some(js))
+
   def httpResponse(responseCode: Int) = HttpResponse.apply(responseCode)
 
   val mockConnector = mock[BirthConnector]
-  val mockAuditConnector = mock[AuditConnector]
 
   object MockLookupService extends LookupService {
     override val groConnector = mockConnector
     override val groniConnector = new GRONIConnector
     override val nrsConnector = new NRSConnector
     override val matchingService = MatchingService
-    override val requestAndResponseAuditor = new RequestsAndResultsAudit(mockAuditConnector)
   }
 
   object MockController extends BirthEventsController {
@@ -76,7 +72,6 @@ class BirthEventsControllerValidationLengthSpec extends UnitSpec with OneAppPerT
 
     "return matched value of true when the firstName length  is less than specified value and request is valid" in {
       when(MockController.service.groConnector.getReference(Matchers.any())(Matchers.any())).thenReturn(Future.successful(httpResponse(groJsonResponseObject20120216)))
-      when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
       val request = postRequest(userValidDOB)
       val result = await(MockController.post().apply(request))
       status(result) shouldBe OK

--- a/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerValidationLengthSpec.scala
+++ b/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerValidationLengthSpec.scala
@@ -25,10 +25,10 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsValue
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.brm.connectors._
-import uk.gov.hmrc.brm.services.{LookupService, MatchingService}
 import uk.gov.hmrc.brm.utils.JsonUtils
+import uk.gov.hmrc.brm.utils.Mocks._
 import uk.gov.hmrc.brm.utils.TestHelper._
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import uk.gov.hmrc.play.http.HttpResponse
 import uk.gov.hmrc.play.test.UnitSpec
 
@@ -46,22 +46,8 @@ class BirthEventsControllerValidationLengthSpec extends UnitSpec with OneAppPerT
 
   def httpResponse(responseCode: Int) = HttpResponse.apply(responseCode)
 
-  val mockConnector = mock[BirthConnector]
-
-  object MockLookupService extends LookupService {
-    override val groConnector = mockConnector
-    override val groniConnector = new GRONIConnector
-    override val nrsConnector = new NRSConnector
-    override val matchingService = MatchingService
-  }
-
-  object MockController extends BirthEventsController {
-    override val service = MockLookupService
-  }
-
   val config: Map[String, _] = Map(
     "microservice.services.birth-registration-matching.validation.maxNameLength" -> 100
-
   )
 
   override def newAppForTest(testData: TestData) = new GuiceApplicationBuilder().configure(
@@ -72,6 +58,8 @@ class BirthEventsControllerValidationLengthSpec extends UnitSpec with OneAppPerT
 
     "return matched value of true when the firstName length  is less than specified value and request is valid" in {
       when(MockController.service.groConnector.getReference(Matchers.any())(Matchers.any())).thenReturn(Future.successful(httpResponse(groJsonResponseObject20120216)))
+      when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
       val request = postRequest(userValidDOB)
       val result = await(MockController.post().apply(request))
       status(result) shouldBe OK
@@ -80,6 +68,8 @@ class BirthEventsControllerValidationLengthSpec extends UnitSpec with OneAppPerT
     }
 
     "return BAD REQUEST 400 if request contains more than 100 characters in firstName " in {
+      when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
       val request = postRequest(firstNameWithMoreThan100Characters)
       val result = await(MockController.post().apply(request))
       status(result) shouldBe BAD_REQUEST
@@ -88,6 +78,8 @@ class BirthEventsControllerValidationLengthSpec extends UnitSpec with OneAppPerT
     }
 
     "return BAD REQUEST 400 if request contains more than 100 characters in lastname " in {
+      when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
       val request = postRequest(lastNameWithMoreThan100Characters)
       val result = await(MockController.post().apply(request))
       status(result) shouldBe BAD_REQUEST

--- a/test/uk/gov/hmrc/brm/services/LookupServiceSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/LookupServiceSpec.scala
@@ -36,7 +36,7 @@ import scala.concurrent.duration.Duration
 class LookupServiceSpec extends UnitSpec with WithFakeApplication with MockitoSugar {
 
   import uk.gov.hmrc.brm.utils.Mocks._
-  
+
   implicit val hc = HeaderCarrier()
 
   "LookupService" when {

--- a/test/uk/gov/hmrc/brm/services/LookupServiceSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/LookupServiceSpec.scala
@@ -39,6 +39,9 @@ class LookupServiceSpec extends UnitSpec with WithFakeApplication with MockitoSu
 
   val mockConnector = mock[BirthConnector]
   val mockAuditConnector = mock[AuditConnector]
+  implicit val auditor = new EnglandAndWalesAudit(mockAuditConnector)
+  implicit val metrics = mock[BRMMetrics]
+  implicit val hc = HeaderCarrier()
 
   object MockService extends LookupService {
     override val groConnector = mockConnector
@@ -46,10 +49,6 @@ class LookupServiceSpec extends UnitSpec with WithFakeApplication with MockitoSu
     override val groniConnector = mockConnector
     override val matchingService = MatchingService
   }
-
-  implicit val auditor = new EnglandAndWalesAudit(mockAuditConnector)
-  implicit val metrics = mock[BRMMetrics]
-  implicit val hc = HeaderCarrier()
 
   "LookupService" when {
 
@@ -155,6 +154,7 @@ class LookupServiceSpec extends UnitSpec with WithFakeApplication with MockitoSu
             |  }
           """.stripMargin)
         when(MockService.groConnector.getReference(Matchers.any())(Matchers.any())).thenReturn(Future.successful(HttpResponse(Status.OK, Some(groResponseValid))))
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
         val service = MockService
         implicit val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
         val result = await(service.lookup)
@@ -203,6 +203,7 @@ class LookupServiceSpec extends UnitSpec with WithFakeApplication with MockitoSu
             |  }
           """.stripMargin)
         when(MockService.groConnector.getChildDetails(Matchers.any())(Matchers.any())).thenReturn(Future.successful(HttpResponse(Status.OK, Some(groResponseInvalid))))
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
         val service = MockService
         implicit val payload = Payload(None, "Adam", "Conder", LocalDate.now, BirthRegisterCountry.ENGLAND)
         val result = await(service.lookup)(Duration.create(5, "seconds"))
@@ -250,6 +251,7 @@ class LookupServiceSpec extends UnitSpec with WithFakeApplication with MockitoSu
             |  }
           """.stripMargin)
         when(MockService.groConnector.getChildDetails(Matchers.any())(Matchers.any())).thenReturn(Future.successful(HttpResponse(Status.OK, Some(groResponseValid))))
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
         val service = MockService
         implicit val payload = Payload(None, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
         val result = await(service.lookup)
@@ -261,13 +263,17 @@ class LookupServiceSpec extends UnitSpec with WithFakeApplication with MockitoSu
     "requesting Scotland" should {
 
       "accept Payload as an argument" in {
-          val service = MockService
-          implicit val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.SCOTLAND)
-          val result = await(service.lookup)
-          result should not be BirthMatchResponse(false)
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+        val service = MockService
+        implicit val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.SCOTLAND)
+        val result = await(service.lookup)
+        result should not be BirthMatchResponse(false)
       }
 
       "accept payload without reference number as argument" in {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val service = MockService
         implicit val payload = Payload(None, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.SCOTLAND)
         val result = await(service.lookup)
@@ -279,13 +285,17 @@ class LookupServiceSpec extends UnitSpec with WithFakeApplication with MockitoSu
     "requesting Northern Ireland" should {
 
       "accept Payload as an argument" in {
-          val service = MockService
-          implicit val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.NORTHERN_IRELAND)
-          val result = await(service.lookup)
-          result should not be BirthMatchResponse(false)
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+        val service = MockService
+        implicit val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.NORTHERN_IRELAND)
+        val result = await(service.lookup)
+        result should not be BirthMatchResponse(false)
       }
 
       "accept payload without reference number as argument" in {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val service = MockService
         implicit val payload = Payload(None, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.NORTHERN_IRELAND)
         val result = await(service.lookup)

--- a/test/uk/gov/hmrc/brm/services/LookupServiceSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/LookupServiceSpec.scala
@@ -22,7 +22,7 @@ import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import play.api.http.Status
 import play.api.libs.json.Json
-import uk.gov.hmrc.brm.audit.{EnglandAndWalesAudit, RequestsAndResultsAudit}
+import uk.gov.hmrc.brm.audit.EnglandAndWalesAudit
 import uk.gov.hmrc.brm.connectors.BirthConnector
 import uk.gov.hmrc.brm.metrics.BRMMetrics
 import uk.gov.hmrc.brm.models.brm.Payload
@@ -45,13 +45,10 @@ class LookupServiceSpec extends UnitSpec with WithFakeApplication with MockitoSu
     override val nrsConnector = mockConnector
     override val groniConnector = mockConnector
     override val matchingService = MatchingService
-    override val requestAndResponseAuditor = new RequestsAndResultsAudit(mockAuditConnector)
   }
 
-  implicit val auditor = new EnglandAndWalesAudit()
-
+  implicit val auditor = new EnglandAndWalesAudit(mockAuditConnector)
   implicit val metrics = mock[BRMMetrics]
-
   implicit val hc = HeaderCarrier()
 
   "LookupService" when {

--- a/test/uk/gov/hmrc/brm/services/LookupServiceSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/LookupServiceSpec.scala
@@ -22,13 +22,11 @@ import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import play.api.http.Status
 import play.api.libs.json.Json
-import uk.gov.hmrc.brm.audit.{EnglandAndWalesAudit, TransactionAuditor}
 import uk.gov.hmrc.brm.connectors.BirthConnector
-import uk.gov.hmrc.brm.metrics.BRMMetrics
 import uk.gov.hmrc.brm.models.brm.Payload
 import uk.gov.hmrc.brm.models.matching.BirthMatchResponse
 import uk.gov.hmrc.brm.utils.BirthRegisterCountry
-import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse, NotImplementedException}
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
@@ -38,20 +36,8 @@ import scala.concurrent.duration.Duration
 class LookupServiceSpec extends UnitSpec with WithFakeApplication with MockitoSugar {
 
   import uk.gov.hmrc.brm.utils.Mocks._
-
-//  val mockConnector = mock[BirthConnector]
-//  val mockAuditConnector = mock[AuditConnector]
-//  implicit val auditor = new EnglandAndWalesAudit(mockAuditConnector)
-//  implicit val metrics = mock[BRMMetrics]
+  
   implicit val hc = HeaderCarrier()
-
-//  object MockLookupService extends LookupService {
-//    override val groConnector = mockConnector
-//    override val nrsConnector = mockConnector
-//    override val groniConnector = mockConnector
-//    override val matchingService = MatchingService
-//    override val transactionAuditor: TransactionAuditor = new TransactionAuditor(mockAuditConnector)
-//  }
 
   "LookupService" when {
 

--- a/test/uk/gov/hmrc/brm/services/MatchingServiceSpec.scala
+++ b/test/uk/gov/hmrc/brm/services/MatchingServiceSpec.scala
@@ -17,22 +17,29 @@
 package uk.gov.hmrc.brm.services
 
 import org.joda.time.LocalDate
+import org.mockito.Matchers
+import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.mock.MockitoSugar
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeApplication
 import play.api.test.Helpers._
+import uk.gov.hmrc.brm.audit.MatchingAudit
 import uk.gov.hmrc.brm.config.BrmConfig
 import uk.gov.hmrc.brm.models.brm.Payload
 import uk.gov.hmrc.brm.utils.TestHelper._
 import uk.gov.hmrc.brm.utils.{BirthRegisterCountry, MatchingType}
 import uk.gov.hmrc.brm.{BRMFakeApplication, BaseConfig}
+import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
 
+import scala.concurrent.Future
 
 
 class MatchingServiceConfigSpec extends UnitSpec with MockitoSugar with BeforeAndAfterAll {
+
+  import uk.gov.hmrc.brm.utils.Mocks._
 
   val configFirstName: Map[String, _] = BaseConfig.config ++ Map(
     "microservice.services.birth-registration-matching.matching.firstName" -> true,
@@ -72,8 +79,10 @@ class MatchingServiceConfigSpec extends UnitSpec with MockitoSugar with BeforeAn
       "return true result for firstName only" in running(
         firstNameApp
       ) {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val payload = Payload(Some("123456789"), "Chris", "wrongLastName", new LocalDate("2008-02-16"), BirthRegisterCountry.ENGLAND)
-        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
         BrmConfig.matchLastName shouldBe false
         resultMatch.isMatch shouldBe true
       }
@@ -81,8 +90,10 @@ class MatchingServiceConfigSpec extends UnitSpec with MockitoSugar with BeforeAn
       "return true result for lastName only" in running(
         lastNameApp
       ) {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val payload = Payload(Some("123456789"), "wrongFirstName", "Jones", new LocalDate("2008-02-16"), BirthRegisterCountry.ENGLAND)
-        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
         BrmConfig.matchFirstName shouldBe false
         BrmConfig.matchDateOfBirth shouldBe false
         resultMatch.isMatch shouldBe true
@@ -91,8 +102,10 @@ class MatchingServiceConfigSpec extends UnitSpec with MockitoSugar with BeforeAn
       "return true result for date of birth only" in running(
         dobApp
       ) {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val payload = Payload(Some("123456789"), "wrongFirstName", "wrongLastName", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
         BrmConfig.matchFirstName shouldBe false
         resultMatch.isMatch shouldBe true
       }
@@ -100,8 +113,10 @@ class MatchingServiceConfigSpec extends UnitSpec with MockitoSugar with BeforeAn
       "return true result for firstName and LastName only" in running(
         firstNameLastNameApp
       ) {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val payload = Payload(Some("123456789"), "chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
         resultMatch.isMatch shouldBe true
       }
 
@@ -112,8 +127,10 @@ class MatchingServiceConfigSpec extends UnitSpec with MockitoSugar with BeforeAn
       "return true result for firstName only" in running(
         firstNameApp
       ) {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val payload = Payload(None, "Chris", "wrongLastName", new LocalDate("2008-02-16"), BirthRegisterCountry.ENGLAND)
-        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
         BrmConfig.matchLastName shouldBe false
         resultMatch.isMatch shouldBe true
       }
@@ -121,8 +138,10 @@ class MatchingServiceConfigSpec extends UnitSpec with MockitoSugar with BeforeAn
       "return true result for lastName only" in running(
         lastNameApp
       ) {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val payload = Payload(None, "wrongFirstName", "Jones", new LocalDate("2008-02-16"), BirthRegisterCountry.ENGLAND)
-        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
         BrmConfig.matchFirstName shouldBe false
         BrmConfig.matchDateOfBirth shouldBe false
         resultMatch.isMatch shouldBe true
@@ -131,8 +150,10 @@ class MatchingServiceConfigSpec extends UnitSpec with MockitoSugar with BeforeAn
       "return true result for date of birth only" in running(
         dobApp
       ) {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val payload = Payload(None, "wrongFirstName", "wrongLastName", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
         BrmConfig.matchFirstName shouldBe false
         resultMatch.isMatch shouldBe true
       }
@@ -140,8 +161,10 @@ class MatchingServiceConfigSpec extends UnitSpec with MockitoSugar with BeforeAn
       "return true result for firstName and LastName only" in running(
         firstNameLastNameApp
       ) {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val payload = Payload(None, "chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-        val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
+        val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.PARTIAL)
         resultMatch.isMatch shouldBe true
       }
 
@@ -153,251 +176,311 @@ class MatchingServiceConfigSpec extends UnitSpec with MockitoSugar with BeforeAn
 
 class MatchingServiceSpec extends UnitSpec with MockitoSugar with BRMFakeApplication {
 
-  def getApp(config: Map[String, _]) = GuiceApplicationBuilder(disabled = Seq(classOf[com.kenshoo.play.metrics.PlayModule])).configure(config).build()
+  import uk.gov.hmrc.brm.utils.Mocks._
 
   implicit val hc = HeaderCarrier()
-
   val references = List(Some("123456789"), None)
+
+  def getApp(config: Map[String, _]) = GuiceApplicationBuilder(disabled = Seq(classOf[com.kenshoo.play.metrics.PlayModule])).configure(config).build()
 
   references.foreach(
     reference => {
 
-      val name = reference match { case Some(x) => "with reference" case None => "without reference" }
+      val name = reference match {
+        case Some(x) => "with reference"
+        case None => "without reference"
+      }
 
-        "" should {
+      "MatchingService" should {
 
-          s"($name) match when firstName contains special characters" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris-Jame's", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordSpecialCharactersFirstName), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
+        s"($name) match when firstName contains special characters" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
 
-          s"($name) match when lastName contains special characters" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jones--Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordSpecialCharactersLastName), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when firstName contains space" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordFirstNameSpace), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when lastName contains space" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameSpace), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when lastName from record contains multiple spaces between names" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jones  Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameSpace), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when lastName from payload contains multiple spaces between names and includes space at beginning and end of string" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "  Jones  Smith  ", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameSpace), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when lastName from payload contains multiple spaces between names" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameMultipleSpace), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when lastName from record contains multiple spaces between names and includes space at beginning and end of string" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameMultipleSpaceBeginningTrailing), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when firstName contains UTF-8 characters" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chrîs", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordUTF8FirstName), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when lastName contains UTF-8 characters" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jonéş", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordUTF8LastName), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match for exact match on firstName and lastName and dateOfBirth on both input and record" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when case is different for firstName, lastName on input" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "chRis", "joNes", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when case is different for firstName, lastName on record" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(wrongCaseValidRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when case is uppercase for firstName, lastName on input" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "CHRIS", "JONES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when case is uppercase for firstName, lastName on record" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "CHRIS", "JONES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecordUppercase), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when case is different for firstName on input" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "chRis", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when case is different for firstName on record" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(wrongCaseFirstNameValidRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when case is different for lastName on input" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "joNES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) match when case is different for lastName on record" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(wrongCaseLastNameValidRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe true
-            }
-          }
-
-          s"($name) not match when firstName and lastName are different on the input" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
-            }
-          }
-
-          s"($name) not match when firstName and lastName are different on the record" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(invalidRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
-            }
-          }
-
-          s"($name) not match when firstName is different on input" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
-            }
-          }
-
-          s"($name) not match when firstName is different on record" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(firstNameNotMatchedRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
-            }
-          }
-
-          s"($name) not match when lastName is different on input" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jone", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
-            }
-          }
-
-          s"($name) not match when lastName is different on record" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(lastNameNotMatchRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
-            }
-          }
-
-          s"($name) not match when dateOfBirth is different on input" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-15"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
-            }
-          }
-
-          s"($name) not match when dateOfBirth is different on record" in {
-            running(FakeApplication()) {
-              val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-15"), BirthRegisterCountry.ENGLAND)
-              val resultMatch = MatchingService.performMatch(payload, List(dobNotMatchRecord), MatchingType.FULL)
-              resultMatch.isMatch shouldBe false
-            }
+            val payload = Payload(reference, "Chris-Jame's", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecordSpecialCharactersFirstName), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
           }
         }
-  })
+
+        s"($name) match when lastName contains special characters" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jones--Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecordSpecialCharactersLastName), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when firstName contains space" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecordFirstNameSpace), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when lastName contains space" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecordLastNameSpace), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when lastName from record contains multiple spaces between names" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jones  Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecordLastNameSpace), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when lastName from payload contains multiple spaces between names and includes space at beginning and end of string" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "  Jones  Smith  ", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecordLastNameSpace), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when lastName from payload contains multiple spaces between names" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecordLastNameMultipleSpace), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when lastName from record contains multiple spaces between names and includes space at beginning and end of string" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecordLastNameMultipleSpaceBeginningTrailing), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when firstName contains UTF-8 characters" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chrîs", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecordUTF8FirstName), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when lastName contains UTF-8 characters" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jonéş", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecordUTF8LastName), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match for exact match on firstName and lastName and dateOfBirth on both input and record" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when case is different for firstName, lastName on input" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "chRis", "joNes", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when case is different for firstName, lastName on record" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(wrongCaseValidRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when case is uppercase for firstName, lastName on input" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "CHRIS", "JONES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when case is uppercase for firstName, lastName on record" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "CHRIS", "JONES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecordUppercase), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when case is different for firstName on input" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "chRis", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when case is different for firstName on record" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(wrongCaseFirstNameValidRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when case is different for lastName on input" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "joNES", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) match when case is different for lastName on record" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(wrongCaseLastNameValidRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe true
+          }
+        }
+
+        s"($name) not match when firstName and lastName are different on the input" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+        }
+
+        s"($name) not match when firstName and lastName are different on the record" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(invalidRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+        }
+
+        s"($name) not match when firstName is different on input" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+        }
+
+        s"($name) not match when firstName is different on record" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Christopher", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(firstNameNotMatchedRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+        }
+
+        s"($name) not match when lastName is different on input" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jone", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+        }
+
+        s"($name) not match when lastName is different on record" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(lastNameNotMatchRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+        }
+
+        s"($name) not match when dateOfBirth is different on input" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-15"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(validRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+        }
+
+        s"($name) not match when dateOfBirth is different on record" in {
+          running(FakeApplication()) {
+            when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
+            val payload = Payload(reference, "Chris", "Jones", new LocalDate("2012-02-15"), BirthRegisterCountry.ENGLAND)
+            val resultMatch = MockMatchingService.performMatch(payload, List(dobNotMatchRecord), MatchingType.FULL)
+            resultMatch.isMatch shouldBe false
+          }
+        }
+      }
+    })
 
 }
+
 class MatchingServiceMiddleNameSpec extends UnitSpec with MockitoSugar with BRMFakeApplication {
+
+  import uk.gov.hmrc.brm.utils.Mocks._
 
   val ignoreMiddleNamesEnabled: Map[String, _] = BaseConfig.config ++ Map(
     "microservice.services.birth-registration-matching.matching.ignoreMiddleNames" -> true
   )
 
-  val ignoreMiddleNamesDisabled : Map[String, _] = BaseConfig.config ++ Map(
+  val ignoreMiddleNamesDisabled: Map[String, _] = BaseConfig.config ++ Map(
     "microservice.services.birth-registration-matching.matching.ignoreMiddleNames" -> false
   )
+  implicit val hc = HeaderCarrier()
 
   def getApp(config: Map[String, _]) = GuiceApplicationBuilder(disabled = Seq(classOf[com.kenshoo.play.metrics.PlayModule])).configure(config).build()
-
-  implicit val hc = HeaderCarrier()
 
   "configuring" should {
 
@@ -415,29 +498,33 @@ class MatchingServiceMiddleNameSpec extends UnitSpec with MockitoSugar with BRMF
 
     "multiple records" should {
 
-      object MockMatchingService extends MatchingService {
-        override val matchOnMultiple = true
-      }
-
       "should return true if a minimum of one record matches" in {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
         val resultMatch = MockMatchingService.performMatch(payload, List(invalidRecord, validRecord), MatchingType.FULL)
         resultMatch.isMatch shouldBe true
       }
 
       "return false if no records match" in {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
         val resultMatch = MockMatchingService.performMatch(payload, List(invalidRecord, invalidRecord), MatchingType.FULL)
         resultMatch.isMatch shouldBe false
       }
 
       "return false result match when List is empty" in {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
         val resultMatch = MockMatchingService.performMatch(payload, List(), MatchingType.FULL)
         resultMatch.isMatch shouldBe false
       }
 
       "return false result match when List contains duplicate matches" ignore {
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val payload = Payload(Some("123456789"), "Chris", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
         val resultMatch = MockMatchingService.performMatch(payload, List(validRecord, validRecord, validRecord), MatchingType.FULL)
         resultMatch.isMatch shouldBe false
@@ -462,78 +549,99 @@ class MatchingServiceMiddleNameSpec extends UnitSpec with MockitoSugar with BRMF
       references.foreach(
         reference => {
 
-          val name = reference match { case Some(x) => "with reference" case None => "without reference" }
+          val name = reference match {
+            case Some(x) => "with reference"
+            case None => "without reference"
+          }
 
           "ignore middle names with feature toggle enabled" should {
 
             s"($name) match when firstName argument has all middle names on input that are on the record" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "Adam David", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
               }
             }
 
             s"($name) match when firstName argument has all middle names on input that on are the record, with additional spaces" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, " Adam    David   ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
               }
             }
 
             s"($name) match when firstName argument has all middle names on input that on are the record, with additional spaces on the record" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "Adam David", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
               }
             }
 
             s"($name) match when firstName argument has middle names with punctuation, with additional names on record" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "   Jamie  Mary-Ann'é ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpacesAndPunctuation), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpacesAndPunctuation), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
               }
             }
 
             s"($name) match when firstName argument has no middle names on input that are on the record" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "Adam", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
               }
             }
 
             s"($name) match when firstName argument has no middle names on input that are on the record, with additional spaces" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "    Adam     ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
               }
             }
 
             s"($name) not match when firstName argument has too many names not on the record" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "Adam David James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe false
               }
             }
 
             s"($name) not match when firstName argument has too many names not on the record, with additional spaces" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "   Adam  David     James  ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe false
               }
             }
 
             s"($name) match when lastName from record contains multiple spaces between names and includes space at beginning and end of string" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesEnabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameMultipleSpaceBeginningTrailing), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordLastNameMultipleSpaceBeginningTrailing), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
               }
             }
@@ -544,56 +652,70 @@ class MatchingServiceMiddleNameSpec extends UnitSpec with MockitoSugar with BRMF
 
             s"($name) match when firstName argument has all middle names on input that are on the record" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "Adam David", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
               }
             }
 
             s"($name) not match when firstName argument has a missing first name on input that is on the record" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "Adam", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe false
               }
             }
 
             s"($name) match when firstName argument has all middle names on input that on are the record, with additional spaces" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, " Adam    David   ", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
               }
             }
 
             s"($name) match when firstName argument has all middle names on input that on are the record, with additional spaces on the record" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "Adam David", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
               }
             }
 
             s"($name) not match when firstName argument has too many names not on the record" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "Adam David James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNames), MatchingType.FULL)
                 resultMatch.isMatch shouldBe false
               }
             }
 
             s"($name) not match when firstName argument has too many names not on the record, with additional spaces on record" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "Adam David James", "Jones", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordMiddleNamesWithSpaces), MatchingType.FULL)
                 resultMatch.isMatch shouldBe false
               }
             }
 
             s"($name) match when lastName from record contains multiple spaces between names and includes space at beginning and end of string" in {
               running(FakeApplication(additionalConfiguration = ignoreMiddleNamesDisabled)) {
+                when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
                 val payload = Payload(reference, "Chris", "Jones Smith", new LocalDate("2012-02-16"), BirthRegisterCountry.ENGLAND)
-                val resultMatch = MatchingService.performMatch(payload, List(validRecordLastNameMultipleSpaceBeginningTrailing), MatchingType.FULL)
+                val resultMatch = MockMatchingService.performMatch(payload, List(validRecordLastNameMultipleSpaceBeginningTrailing), MatchingType.FULL)
                 resultMatch.isMatch shouldBe true
               }
             }

--- a/test/uk/gov/hmrc/brm/utils/BirthRegisterCountrySpec.scala
+++ b/test/uk/gov/hmrc/brm/utils/BirthRegisterCountrySpec.scala
@@ -21,12 +21,13 @@ import uk.gov.hmrc.play.test.UnitSpec
 class BirthRegisterCountrySpec extends UnitSpec {
 
   "BirthRegisterCountry" should {
+
     "return england for name england" in {
       BirthRegisterCountry.ENGLAND shouldBe BirthRegisterCountry.withName("england")
     }
 
     "return valid response for four countries" in {
-      val countryList = List("england", "wales", "scotland", "northern ireland");
+      val countryList = List("england", "wales", "scotland", "northern ireland")
 
       for (country <- countryList) {
         BirthRegisterCountry.withName(country)

--- a/test/uk/gov/hmrc/brm/utils/BirthResponseBuilderSpec.scala
+++ b/test/uk/gov/hmrc/brm/utils/BirthResponseBuilderSpec.scala
@@ -21,6 +21,7 @@ import uk.gov.hmrc.play.test.UnitSpec
 class BirthResponseBuilderSpec extends UnitSpec {
 
   "BirthResponseBuilder" should {
+
     "return matched true with Match" in {
       BirthResponseBuilder.withMatch().matched shouldBe true
     }
@@ -32,6 +33,7 @@ class BirthResponseBuilderSpec extends UnitSpec {
     "return matched true with input value as true" in {
       BirthResponseBuilder.getResponse(true).matched  shouldBe true
     }
+
   }
 
 }

--- a/test/uk/gov/hmrc/brm/utils/BrmLoggerSpec.scala
+++ b/test/uk/gov/hmrc/brm/utils/BrmLoggerSpec.scala
@@ -24,9 +24,7 @@ import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 class BrmLoggerSpec extends UnitSpec with MockitoSugar with BeforeAndAfter with WithFakeApplication {
 
-  val mockLogger = mock[org.slf4j.Logger]
-
-  object MockBRMLogger extends BrmLogger(mockLogger)
+  import uk.gov.hmrc.brm.utils.Mocks._
 
   before {
     reset(mockLogger)
@@ -34,7 +32,7 @@ class BrmLoggerSpec extends UnitSpec with MockitoSugar with BeforeAndAfter with 
 
   "BrmLogger" should {
     "info call Logger info" in {
-      Keygenerator.setKey("somekey")
+      KeyGenerator.setKey("somekey")
       MockBRMLogger.info(this, "methodName", "message")
       val argumentCapture = new ArgumentCapture[String]
       verify(mockLogger, times(1)).info(argumentCapture.capture)

--- a/test/uk/gov/hmrc/brm/utils/HeaderValidatorSpec.scala
+++ b/test/uk/gov/hmrc/brm/utils/HeaderValidatorSpec.scala
@@ -16,19 +16,14 @@
 
 package uk.gov.hmrc.brm.utils
 
-import akka.stream.Materializer
 import org.mockito.Matchers
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
-import play.api.Play
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.brm.connectors.BirthConnector
-import uk.gov.hmrc.brm.controllers.{BRMBaseController, BirthEventsController}
-import uk.gov.hmrc.brm.services.{LookupService, MatchingService}
-import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import uk.gov.hmrc.play.http.HttpResponse
 import uk.gov.hmrc.play.test.UnitSpec
 
@@ -36,23 +31,9 @@ import scala.concurrent.Future
 
 class HeaderValidatorSpec extends UnitSpec with OneAppPerSuite with MockitoSugar {
 
+  import uk.gov.hmrc.brm.utils.Mocks._
+
   private val jsonResponse = """{"code":"145","status":"400","details":"The headers you supplied are invalid","title":"Headers invalid","about":"http://http://htmlpreview.github.io/?https://github.com/hmrc/birth-registration-matching/blob/master/api-documents/api.html"}"""
-
-  val mockConnector = mock[BirthConnector]
-  val mockAuditConnector = mock[AuditConnector]
-
-  object MockLookupService extends LookupService {
-    override val groConnector = mockConnector
-    override val groniConnector = mockConnector
-    override val nrsConnector = mockConnector
-    override val matchingService = MatchingService
-  }
-
-  implicit lazy val materializer = Play.current.injector.instanceOf[Materializer]
-
-  object MockController extends BirthEventsController with BRMBaseController {
-    override val service = MockLookupService
-  }
 
   object HeaderValidator extends HeaderValidator
 
@@ -112,8 +93,10 @@ class HeaderValidatorSpec extends UnitSpec with OneAppPerSuite with MockitoSugar
         val request = FakeRequest("POST", "/api/v0/events/birth")
           .withHeaders((ACCEPT, "application/vnd.hmrc.1.0+json"), ("Audit-Source", "DFS"))
           .withBody(payload)
+
         when(mockConnector.getReference(Matchers.any())(Matchers.any())).thenReturn(Future.successful(httpResponse(groJsonResponseObject)))
         when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val result = await(MockController.post().apply(request))
         status(result) shouldBe OK
       }
@@ -124,6 +107,9 @@ class HeaderValidatorSpec extends UnitSpec with OneAppPerSuite with MockitoSugar
         val request = FakeRequest("POST", "/api/v0/events/birth")
           .withHeaders((ACCEPT, "application/vnd.hmrc.1.0+xml"), ("Audit-Source", "DFS"))
           .withBody(payload)
+
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val result = await(MockController.post().apply(request))
         status(result) shouldBe BAD_REQUEST
         bodyOf(result) shouldBe jsonResponse
@@ -135,6 +121,9 @@ class HeaderValidatorSpec extends UnitSpec with OneAppPerSuite with MockitoSugar
         val request = FakeRequest("POST", "/api/v0/events/birth")
           .withHeaders((ACCEPT, "application/vnd.hmrc.1+json"), ("Audit-Source", "DFS"))
           .withBody(payload)
+
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val result = await(MockController.post().apply(request))
         status(result) shouldBe BAD_REQUEST
         bodyOf(result) shouldBe jsonResponse
@@ -146,6 +135,9 @@ class HeaderValidatorSpec extends UnitSpec with OneAppPerSuite with MockitoSugar
         val request = FakeRequest("POST", "/api/v0/events/birth")
           .withHeaders(("Audit-Source", "DFS"))
           .withBody(payload)
+
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val result = await(MockController.post().apply(request))
         status(result) shouldBe BAD_REQUEST
         bodyOf(result) shouldBe jsonResponse
@@ -157,6 +149,9 @@ class HeaderValidatorSpec extends UnitSpec with OneAppPerSuite with MockitoSugar
         val request = FakeRequest("POST", "/api/v0/events/birth")
           .withHeaders((ACCEPT, "application/vnd.hmrc.1.0+json"), ("Audit-Source", ""))
           .withBody(payload)
+
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val result = await(MockController.post().apply(request))
         status(result) shouldBe BAD_REQUEST
         bodyOf(result) shouldBe jsonResponse
@@ -168,6 +163,9 @@ class HeaderValidatorSpec extends UnitSpec with OneAppPerSuite with MockitoSugar
         val request = FakeRequest("POST", "/api/v0/events/birth")
           .withHeaders((ACCEPT, "application/vnd.hmrc.1.0+json"))
           .withBody(payload)
+
+        when(mockAuditConnector.sendEvent(Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
+
         val result = await(MockController.post().apply(request))
         status(result) shouldBe BAD_REQUEST
         bodyOf(result) shouldBe jsonResponse

--- a/test/uk/gov/hmrc/brm/utils/HeaderValidatorSpec.scala
+++ b/test/uk/gov/hmrc/brm/utils/HeaderValidatorSpec.scala
@@ -25,7 +25,6 @@ import play.api.Play
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.brm.audit.RequestsAndResultsAudit
 import uk.gov.hmrc.brm.connectors.BirthConnector
 import uk.gov.hmrc.brm.controllers.BirthEventsController
 import uk.gov.hmrc.brm.services.{LookupService, MatchingService}
@@ -47,7 +46,6 @@ class HeaderValidatorSpec extends UnitSpec with OneAppPerSuite with MockitoSugar
     override val groniConnector = mockConnector
     override val nrsConnector = mockConnector
     override val matchingService = MatchingService
-    override val requestAndResponseAuditor = new RequestsAndResultsAudit(mockAuditConnector)
   }
 
   implicit lazy val materializer = Play.current.injector.instanceOf[Materializer]

--- a/test/uk/gov/hmrc/brm/utils/HeaderValidatorSpec.scala
+++ b/test/uk/gov/hmrc/brm/utils/HeaderValidatorSpec.scala
@@ -26,7 +26,7 @@ import play.api.libs.json.{JsValue, Json}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.brm.connectors.BirthConnector
-import uk.gov.hmrc.brm.controllers.BirthEventsController
+import uk.gov.hmrc.brm.controllers.{BRMBaseController, BirthEventsController}
 import uk.gov.hmrc.brm.services.{LookupService, MatchingService}
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 import uk.gov.hmrc.play.http.HttpResponse

--- a/test/uk/gov/hmrc/brm/utils/KeyGeneratorSpec.scala
+++ b/test/uk/gov/hmrc/brm/utils/KeyGeneratorSpec.scala
@@ -27,36 +27,33 @@ import play.api.mvc.{Headers, Request}
 import uk.gov.hmrc.play.test.UnitSpec
 
 class KeyGeneratorSpec extends UnitSpec with MockitoSugar with BeforeAndAfter {
-  val mockRequest = mock[Request[JsValue]]
-  val headers = mock[Headers]
 
+  import uk.gov.hmrc.brm.utils.Mocks._
 
   before {
     reset(mockRequest)
     reset(headers)
   }
 
-
   "KeyGenerator" should {
+
     "returns key" in {
       when(mockRequest.id).thenReturn(10)
       when(mockRequest.headers).thenReturn(headers)
       when(headers.get(Matchers.any())).thenReturn(Some("dfs"))
       val date = new DateTime(2009, 10, 10, 5, 10, 10)
       DateTimeUtils.setCurrentMillisFixed(date.getMillis)
-      Keygenerator.generateKey(mockRequest).isEmpty shouldBe false
+      KeyGenerator.generateKey(mockRequest).isEmpty shouldBe false
     }
 
-
     "return key as 20160915:05101000-0-dfs-1.0 for audio source dfs and version 1.0" in {
-
       when(mockRequest.headers).thenReturn(headers)
       when(headers.get("Audit-Source")).thenReturn(Some("dfs"))
       when(headers.get(HeaderNames.ACCEPT)).thenReturn(Some("application/vnd.hmrc.1.0+json"))
       val date = new DateTime(2016, 9, 15, 5, 10, 10)
       DateTimeUtils.setCurrentMillisFixed(date.getMillis)
 
-      val key = Keygenerator.generateKey(mockRequest)
+      val key = KeyGenerator.generateKey(mockRequest)
       key shouldBe "20160915:05101000-0-dfs-1.0"
       key.contains("dfs") shouldBe true
       key.contains("20160915:051010") shouldBe true
@@ -64,58 +61,53 @@ class KeyGeneratorSpec extends UnitSpec with MockitoSugar with BeforeAndAfter {
     }
 
     "return key when audio source is empty" in {
-
       when(mockRequest.headers).thenReturn(headers)
       when(headers.get("Audit-Source")).thenReturn(None)
       when(headers.get(HeaderNames.ACCEPT)).thenReturn(Some("application/vnd.hmrc.1.0+json"))
       val date = new DateTime(2016, 9, 15, 5, 10, 10)
       DateTimeUtils.setCurrentMillisFixed(date.getMillis)
-      val key = Keygenerator.generateKey(mockRequest)
+      val key = KeyGenerator.generateKey(mockRequest)
       key shouldBe "20160915:05101000-0--1.0"
       key.contains("dfs") shouldBe false
       key.contains("1.0") shouldBe true
     }
 
     "return key when request id is empty" in {
-
       when(mockRequest.headers).thenReturn(headers)
       when(headers.get("Audit-Source")).thenReturn(Some("dfs"))
       when(headers.get(HeaderNames.ACCEPT)).thenReturn(Some("application/vnd.hmrc.1.0+json"))
       val date = new DateTime(2016, 9, 15, 5, 10, 10)
       DateTimeUtils.setCurrentMillisFixed(date.getMillis)
-      val key = Keygenerator.generateKey(mockRequest)
+      val key = KeyGenerator.generateKey(mockRequest)
       key shouldBe "20160915:05101000-0-dfs-1.0"
 
     }
 
 
     "return key when version is empty" in {
-
       when(mockRequest.headers).thenReturn(headers)
       when(headers.get("Audit-Source")).thenReturn(Some("dfs"))
       when(headers.get(HeaderNames.ACCEPT)).thenReturn(None)
       val date = new DateTime(2016, 9, 15, 5, 10, 10)
       DateTimeUtils.setCurrentMillisFixed(date.getMillis)
-      val key = Keygenerator.generateKey(mockRequest)
+      val key = KeyGenerator.generateKey(mockRequest)
       key shouldBe "20160915:05101000-0-dfs-"
 
     }
 
     "return key contains version 2.0 for version 2.0." in {
-
       when(mockRequest.headers).thenReturn(headers)
       when(headers.get("Audit-Source")).thenReturn(Some("dfs"))
       when(headers.get(HeaderNames.ACCEPT)).thenReturn(Some("application/vnd.hmrc.2.0+json"))
       val date = new DateTime(2016, 9, 15, 5, 10, 10)
       DateTimeUtils.setCurrentMillisFixed(date.getMillis)
-      val key = Keygenerator.generateKey(mockRequest)
+      val key = KeyGenerator.generateKey(mockRequest)
       key.contains("2.0") shouldBe true
 
     }
   }
 
-  after{
-
+  after {
     DateTimeUtils.setCurrentMillisSystem()
   }
 

--- a/test/uk/gov/hmrc/brm/utils/Mocks.scala
+++ b/test/uk/gov/hmrc/brm/utils/Mocks.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.brm.utils
+
+import akka.stream.Materializer
+import org.scalatest.mock.MockitoSugar
+import play.api.Play
+import play.api.libs.json.JsValue
+import play.api.mvc.{Headers, Request}
+import uk.gov.hmrc.brm.audit._
+import uk.gov.hmrc.brm.connectors.{BirthConnector, GROConnector, GRONIConnector, NRSConnector}
+import uk.gov.hmrc.brm.controllers.BirthEventsController
+import uk.gov.hmrc.brm.implicits.Implicits.AuditFactory
+import uk.gov.hmrc.brm.models.brm.Payload
+import uk.gov.hmrc.brm.services.{LookupService, MatchingService}
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+import uk.gov.hmrc.play.http.HttpPost
+
+/**
+  * Created by adamconder on 24/02/2017.
+  */
+object Mocks extends MockitoSugar {
+
+  implicit lazy val materializer = Play.current.injector.instanceOf[Materializer]
+
+  val mockConnector = mock[BirthConnector]
+  val mockAuditConnector = mock[AuditConnector]
+  val mockHttpPost = mock[HttpPost]
+  val mockLookupService = mock[LookupService]
+  val mockLogger = mock[org.slf4j.Logger]
+  val mockRequest = mock[Request[JsValue]]
+  val headers = mock[Headers]
+
+  object MockBRMLogger extends BRMLogger(mockLogger)
+
+  object MockMatchingService extends MatchingService {
+    override val matchOnMultiple: Boolean = true
+    override val auditor = auditorFixtures.matchingAudit
+  }
+
+  object MockLookupService extends LookupService {
+    override val groConnector = mockConnector
+    override val groniConnector = new GRONIConnector
+    override val nrsConnector = new NRSConnector
+    override val matchingService = MockMatchingService
+  }
+
+  object MockAuditFactory extends AuditFactory {
+    override def getAuditor()(implicit payload: Payload): BRMAudit = auditorFixtures.englandAndWalesAudit
+  }
+
+  object MockController extends BirthEventsController {
+    override val service = MockLookupService
+    override val auditor = auditorFixtures.whereBirthRegisteredAudit
+    override val auditFactory = MockAuditFactory
+  }
+
+  object MockControllerMockedLookup extends BirthEventsController {
+    override val service = mockLookupService
+    override val auditor = auditorFixtures.whereBirthRegisteredAudit
+    override val auditFactory = MockAuditFactory
+  }
+
+  def connectorFixtures = {
+    new {
+      val groConnector = new GROConnector(mockHttpPost)
+      val nrsConnector = new NRSConnector(auditor = new ScotlandAudit(mockAuditConnector))
+      val groniConnector = new GRONIConnector(auditor = new NorthernIrelandAudit(mockAuditConnector))
+    }
+  }
+
+  def auditorFixtures = {
+    new {
+      val whereBirthRegisteredAudit = new WhereBirthRegisteredAudit(mockAuditConnector)
+      val englandAndWalesAudit = new EnglandAndWalesAudit(mockAuditConnector)
+      val scotlandAudit = new ScotlandAudit(mockAuditConnector)
+      val northernIrelandAudit = new NorthernIrelandAudit(mockAuditConnector)
+      val matchingAudit = new MatchingAudit(mockAuditConnector)
+      val transactionAudit = new TransactionAuditor(mockAuditConnector)
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/brm/utils/Mocks.scala
+++ b/test/uk/gov/hmrc/brm/utils/Mocks.scala
@@ -52,6 +52,11 @@ object Mocks extends MockitoSugar {
     override val auditor = auditorFixtures.matchingAudit
   }
 
+  object MockMatchingServiceMatchMultipleFalse extends MatchingService {
+    override val matchOnMultiple: Boolean = false
+    override val auditor = auditorFixtures.matchingAudit
+  }
+
   object MockLookupService extends LookupService {
     override val groConnector = mockConnector
     override val groniConnector = new GRONIConnector


### PR DESCRIPTION
- Moving common methods into BRMAudit
- TransactionAuditor now has responsibility for building `Map[String, String]` for audit event rather than being provided as an argument
- All exceptions are now auditing the transaction and the result with defaults