### PR TITLE
BRMS-313: Remove multiple spaces within names

### DIFF
--- a/app/uk/gov/hmrc/brm/services/parser/NameParser.scala
+++ b/app/uk/gov/hmrc/brm/services/parser/NameParser.scala
@@ -28,11 +28,17 @@ object NameParser {
 
     lazy val regex = BrmConfig.ignoreMiddleNamesRegex
 
-    def names: List[String] = {
-      val nameArray: Array[String] = s.toLowerCase.trim.split(regex)
-      BRMLogger.debug("NameParser", "parse", s"names: ${nameArray.toList}, regex: $regex")
+    private def toList(x: Array[String], key: String) = {
+      BRMLogger.debug("NameParser", "parse", s"$key: ${x.toList}, regex: $regex")
+      x.toList
+    }
 
-      nameArray.toList
+    def names: List[String] = {
+      toList(s.toLowerCase.trim.split(regex), "names")
+    }
+
+    def namesOriginalCase: List[String] = {
+      toList(s.trim.split(regex), "namesOriginalCase")
     }
 
   }

--- a/app/uk/gov/hmrc/brm/utils/CommonUtil.scala
+++ b/app/uk/gov/hmrc/brm/utils/CommonUtil.scala
@@ -16,11 +16,10 @@
 
 package uk.gov.hmrc.brm.utils
 
-import play.api.mvc.Controller
 import uk.gov.hmrc.brm.config.BrmConfig
 import uk.gov.hmrc.brm.models.brm.Payload
 
-object CommonUtil extends Controller {
+object CommonUtil {
 
   abstract class RequestType
 
@@ -39,8 +38,6 @@ object CommonUtil extends Controller {
     }
   }
 
-
-  //add additional name to firstname if ignore middle name is false.
   def forenames(firstName: String, additionalName: Option[String]): String = {
     val forenames = BrmConfig.ignoreAdditionalNames match {
       case true => NameFormat(firstName)

--- a/app/uk/gov/hmrc/brm/utils/Format.scala
+++ b/app/uk/gov/hmrc/brm/utils/Format.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.brm.utils
 
+import uk.gov.hmrc.brm.services.parser.NameParser._
+
 object Trim {
   def apply(v: String): String = {
     v.trim
@@ -39,7 +41,15 @@ object LeadingZeros {
 object NameFormat {
 
   def apply(v: String): String = {
-    Trim.apply(v)
+    RemoveMultipleSpaces.apply(v)
+  }
+}
+
+
+object RemoveMultipleSpaces {
+
+  def apply(v: String): String = {
+    v.namesOriginalCase.listToString
   }
 }
 

--- a/test/uk/gov/hmrc/brm/audit/TransactionAuditorSpec.scala
+++ b/test/uk/gov/hmrc/brm/audit/TransactionAuditorSpec.scala
@@ -49,10 +49,15 @@ class TransactionAuditorSpec extends UnitSpec with MockitoSugar with OneAppPerSu
   "RequestsAndResultsAudit" should {
 
     "audit request and result when child's reference number used" in {
+      val child = Record(Child(
+        500035710: Int,
+        "John",
+        "Smith",
+        Some(new LocalDate("2009-06-30"))))
       val localDate = new LocalDate("2017-02-17")
       val payload = Payload(Some("123456789"), "Adam", None, "Test", localDate, BirthRegisterCountry.ENGLAND)
       val argumentCapture = new ArgumentCapture[AuditEvent]
-      val event = auditor.transactionToMap(payload, Nil, ResultMatch(Bad(), Bad(), Bad(), Bad()))
+      val event = auditor.transactionToMap(payload, List(child), ResultMatch(Bad(), Bad(), Bad(), Bad()))
 
       when(mockAuditConnector.sendEvent(argumentCapture.capture)(Matchers.any(), Matchers.any())).thenReturn(Future.successful(AuditResult.Success))
       val result = await(auditor.audit(event, Some(payload)))

--- a/test/uk/gov/hmrc/brm/utils/CommonUtilSpec.scala
+++ b/test/uk/gov/hmrc/brm/utils/CommonUtilSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.brm.utils
+
+import org.scalatestplus.play.OneAppPerTest
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.test.UnitSpec
+
+class CommonUtilSpec extends UnitSpec with OneAppPerTest {
+
+  lazy val ignoreAdditionalNamesEnabled: Map[String, Boolean] = Map(
+    "microservice.services.birth-registration-matching.matching.ignoreAdditionalNames" -> true
+  )
+
+  lazy val ignoreAdditionalNamesDisabled: Map[String, Boolean] = Map(
+    "microservice.services.birth-registration-matching.matching.ignoreAdditionalNames" -> false
+  )
+
+  val ignoreAdditionalNamesOnAppEnabled = GuiceApplicationBuilder(disabled = Seq(classOf[com.kenshoo.play.metrics.PlayModule])).configure(ignoreAdditionalNamesEnabled).build()
+  val ignoreAdditionalNamesOnAppDisabled = GuiceApplicationBuilder(disabled = Seq(classOf[com.kenshoo.play.metrics.PlayModule])).configure(ignoreAdditionalNamesDisabled).build()
+
+  "forenames" should {
+
+    "ignore additionalNames argument if ignoreAdditionalNames is set to true" in running(ignoreAdditionalNamesOnAppEnabled){
+      CommonUtil.forenames("John", Some("Jones")) shouldBe "John"
+    }
+
+    "return additionalNames argument if ignoreAdditionalNames is set to false" in running(ignoreAdditionalNamesOnAppDisabled) {
+      CommonUtil.forenames("John", Some("Jones")) shouldBe "John Jones"
+    }
+
+    "return string with trailing and ending space trimmed when ignoreAdditionalNames is set to true" in running(ignoreAdditionalNamesOnAppEnabled){
+      CommonUtil.forenames(" John   ", Some("  Jones  Smith  ")) shouldBe "John"
+    }
+
+    "return string with trailing and ending space trimmed when ignoreAdditionalNames is set to false" in running(ignoreAdditionalNamesOnAppDisabled) {
+      CommonUtil.forenames(" John   ", Some("  Jones Smith  ")) shouldBe "John Jones Smith"
+    }
+
+    "convert multiple space separated words to single space separated words" in running(ignoreAdditionalNamesOnAppDisabled) {
+      CommonUtil.forenames("  John   ", Some("  Jones  Smith  ")) shouldBe "John Jones Smith"
+    }
+
+  }
+
+}


### PR DESCRIPTION
@manishsw 

Formatting of names now checks for multiple spaces between strings and removes them.

Count of names submitted to service and names returned from GRO/NRS is now logged in Kibana

Note: This only happens when a successful record is returned. We discussed and didn't see any reason why we should log name count in Kibana if a record wasn't successfully returned.

There is not config to specify if words should be dropped, GRO accepts 20+ names so it's probably not an issue