### PR TITLE
DDCNOS-5999 | adding logger for custom dashboard

### DIFF
--- a/app/uk/gov/hmrc/brm/connectors/BirthConnector.scala
+++ b/app/uk/gov/hmrc/brm/connectors/BirthConnector.scala
@@ -74,8 +74,10 @@ trait BirthConnector extends ServicesConfig {
 
     BRMLogger.debug("BirthConnector", "sendRequest", s"[Request]: $request [HeaderCarrier withExtraHeaders]: $newHc")
 
-    response.onComplete(r =>
+    response.onComplete(r => {
+      BRMLogger.warn("BirthConnector", "sendRequest", s"[HttpResponse]: [status] ${r.map(_.status)}")
       BRMLogger.debug("BirthConnector", "sendRequest", s"[HttpResponse]: [status] ${r.map(_.status)} [body] ${r.map(_.body)} [headers] ${r.map(_.allHeaders)}")
+    }
     )
 
     response

--- a/app/uk/gov/hmrc/brm/connectors/BirthConnector.scala
+++ b/app/uk/gov/hmrc/brm/connectors/BirthConnector.scala
@@ -75,7 +75,7 @@ trait BirthConnector extends ServicesConfig {
     BRMLogger.debug("BirthConnector", "sendRequest", s"[Request]: $request [HeaderCarrier withExtraHeaders]: $newHc")
 
     response.onComplete(r => {
-      BRMLogger.warn("BirthConnector", "sendRequest", s"[HttpResponse]: [status] ${r.map(_.status)}")
+      BRMLogger.warn("BirthConnector", "sendRequest", s"[HttpResponse]: ${r.map(_.status)}")
       BRMLogger.debug("BirthConnector", "sendRequest", s"[HttpResponse]: [status] ${r.map(_.status)} [body] ${r.map(_.body)} [headers] ${r.map(_.allHeaders)}")
     }
     )


### PR DESCRIPTION
Logging is going to look like this :
[BirthConnector][sendRequest] : [[HttpResponse]: Failure(uk.gov.hmrc.http.Upstream5xxResponse: POST of 'http://localhost:9006/birth-registration-matching-proxy/match/reference' returned 500. Response body: '{"code":"GRO_CONNECTION_DOWN","message":"Connection to GRO is down"}')]]