### PR TITLE
[DDCE-5530] Re-implement min length on additionalNames field

### DIFF
--- a/app/uk/gov/hmrc/brm/models/brm/Payload.scala
+++ b/app/uk/gov/hmrc/brm/models/brm/Payload.scala
@@ -119,7 +119,7 @@ object Payload {
         nameValidation keepAnd minLength[String](1) keepAnd maxLength[String](nameMaxLength)
       ) and
       (JsPath \ additionalNames).readNullable[String](
-        nameValidation keepAnd maxLength[String](nameMaxLength)
+        nameValidation keepAnd minLength[String](1) keepAnd maxLength[String](nameMaxLength)
       ) and
       (JsPath \ lastName).read[String](
         nameValidation keepAnd minLength[String](1) keepAnd maxLength[String](nameMaxLength)

--- a/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerAdditionalNameSwitchSpec.scala
+++ b/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerAdditionalNameSwitchSpec.scala
@@ -429,11 +429,11 @@ class BirthEventsControllerAdditionalNameSwitchSpec
 
   "validate additionalNames when ignoreAdditionalName is false." should {
 
-    "return response code 200 if request contains additionalName key but no value" in {
+    "return response code 400 if request contains additionalName key but no value" in {
       mockAuditSuccess
       val request = postRequest(additionalNamesKeyNoValue)
       val result  = testController.post().apply(request).futureValue
-      checkResponse(result, OK, matchResponse = false)
+      checkResponse(result, BAD_REQUEST, MockErrorResponses.INVALID_ADDITIONALNAMES.json)
     }
 
     "return response code 400 if request contains special characters in additionalName" in {

--- a/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerSpec.scala
+++ b/test/uk/gov/hmrc/brm/controllers/BirthEventsControllerSpec.scala
@@ -217,11 +217,11 @@ class BirthEventsControllerSpec
 
     "validate additionalNames" should {
 
-      "return response code 200 if request contains additionalNames key but no value" in {
+      "return response code 400 if request contains additionalNames key but no value" in {
         mockAuditSuccess
         val request = postRequest(additionalNamesKeyNoValue)
         val result  = testController.post().apply(request).futureValue
-        checkResponse(result, OK, matchResponse = true)
+        checkResponse(result, BAD_REQUEST, MockErrorResponses.INVALID_ADDITIONALNAMES.json)
       }
 
       "return response code 400 if request contains special characters in additionalNames" in {

--- a/test/uk/gov/hmrc/brm/models/PayloadSpec.scala
+++ b/test/uk/gov/hmrc/brm/models/PayloadSpec.scala
@@ -247,9 +247,9 @@ class PayloadSpec extends AnyWordSpecLike with Matchers with OptionValues with G
         Json.toJson(payload).validate[Payload].isSuccess shouldBe true
       }
 
-      "return success when additionalNames key exists but value is empty" in {
+      "return failure when additionalNames key exists but value is empty" in {
         val payload = Payload(None, "Test", Some(""), "Test", LocalDate.now, BirthRegisterCountry.ENGLAND)
-        Json.toJson(payload).validate[Payload].isSuccess shouldBe true
+        Json.toJson(payload).validate[Payload].isSuccess shouldBe false
       }
 
       "return error when additionalNames value is an int" in {


### PR DESCRIPTION
Required AT changes: https://github.com/hmrc/birth-registration-matching-acceptance-tests/pull/38